### PR TITLE
Allow project lookup by Key

### DIFF
--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStep.java
@@ -122,8 +122,8 @@ public class NewIssueStep extends BasicJiraStep {
           return buildErrorResponse(new RuntimeException(errorMessage));
         }
 
-        if (issue.getFields().getProject().getId() == 0) {
-          errorMessage = "fields->project->id is zero or missing";
+        if (issue.getFields().getProject().getId() == 0 && issue.getFields().getProject().getKey() == null) {
+          errorMessage = "fields->project->id is zero or missing and fields->project->key was not specified, one must be present";
         }
 
         if (errorMessage != null) {

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStepTest.java
@@ -65,6 +65,12 @@ public class NewIssueStepTest {
           .project(Project.builder().id(10000).build())
           .issuetype(IssueType.builder().id(10000).build()).build())
       .build();
+  
+  final IssueInput issueWithProjectKey = IssueInput.builder()
+      .fields(FieldsInput.builder().description("TEST").summary("TEST")
+          .project(Project.builder().key("TESTPROJECT").build())
+          .issuetype(IssueType.builder().id(10000).build()).build())
+      .build();
 
   @Before
   public void setup() throws IOException, InterruptedException {
@@ -100,6 +106,19 @@ public class NewIssueStepTest {
 
     // Assert Test
     verify(jiraServiceMock, times(1)).createIssue(issue);
+    assertThat(step.isFailOnError()).isEqualTo(true);
+  }
+
+  @Test
+  public void testSuccessfulNewIssueWithProjectKey() throws Exception {
+    final NewIssueStep step = new NewIssueStep(issueWithProjectKey);
+    stepExecution = new NewIssueStep.Execution(step, contextMock);;
+
+    // Execute Test.
+    stepExecution.run();
+
+    // Assert Test
+    verify(jiraServiceMock, times(1)).createIssue(issueWithProjectKey);
     assertThat(step.isFailOnError()).isEqualTo(true);
   }
 }


### PR DESCRIPTION
This PR allows users to look up projects by their key (project name) rather than by their ID. 

Currently, a workaround is: 
```
    def project = jiraGetProject idOrKey: "MYPROJECT", site: "LOCAL"
    def projectid = project.data['id']

    def testIssue = [fields: [ project: [id: projectid],
                     summary: "a summary",
                     description: "a description",
                     ....
```

This is not super practical as it would be a better user experience to pass the key of a project in directly since no one probably memorizes their project IDs. 

This PR will not error if either an ID or a KEY is specified so the use case of:
```
    def testIssue = [fields: [ project: [key: 'MYPROJECT'],
                     summary: "a summary",
                     description: "a description",
                     ....
```
will work without the workaround. 