### PR TITLE
Optional audit log in comment, issue, component, and version

### DIFF
--- a/docs/pages/steps/jira_add_comment.md
+++ b/docs/pages/steps/jira_add_comment.md
@@ -21,6 +21,7 @@ Add comment to the given issue.
 * **comment** - comment, supports jira wiki formatting.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+* **auditLog** - Optional. default: `true`. Append a panel to the comment with the build url and build user name.
 
 Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
 

--- a/docs/pages/steps/jira_edit_component.md
+++ b/docs/pages/steps/jira_edit_component.md
@@ -19,6 +19,7 @@ Note: Sometimes it may not possible to directly edit component (rename it) witho
 * **component** - component to be edited.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+* **auditLog** - Optional. default: `true`. Append the build url and build user name to the description.
 
 Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
 

--- a/docs/pages/steps/jira_edit_version.md
+++ b/docs/pages/steps/jira_edit_version.md
@@ -21,6 +21,7 @@ TODO: probably we should try move version
 * **version** - version to be edited.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+* **auditLog** - Optional. default: `true`. Append the build url and build user name to the description.
 
 Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
 

--- a/docs/pages/steps/jira_new_component.md
+++ b/docs/pages/steps/jira_new_component.md
@@ -19,6 +19,7 @@ Create new component based on given input, which should have some minimal inform
 * **component** - component to be created.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+* **auditLog** - Optional. default: `true`. Append the build url and build user name to the description.
 
 Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
 

--- a/docs/pages/steps/jira_new_issue.md
+++ b/docs/pages/steps/jira_new_issue.md
@@ -19,6 +19,7 @@ Creates new issue based on given input, which should have some minimal informati
 * **issue** - issue to be created.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+* **auditLog** - Optional. default: `true`. Append a panel to the comment with the build url and build user name.
 
 Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
 

--- a/docs/pages/steps/jira_new_issues.md
+++ b/docs/pages/steps/jira_new_issues.md
@@ -17,6 +17,7 @@ Creates issues in bulk.
 * **issues** - issues to be created.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+* **auditLog** - Optional. default: `true`. Append a panel to the comment with the build url and build user name.
 
 Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
 

--- a/docs/pages/steps/jira_new_version.md
+++ b/docs/pages/steps/jira_new_version.md
@@ -17,6 +17,7 @@ Creates new version based on given input, which should have some minimal informa
 * **version** - version to be created.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+* **auditLog** - Optional. default: `true`. Append the build url and build user name to the description.
 
 Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
 

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddCommentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddCommentStep.java
@@ -77,7 +77,8 @@ public class AddCommentStep extends BasicJiraStep {
       if (response == null) {
         logger.println("JIRA: Site - " + siteName + " - Add new comment: " + step.getComment()
             + " on issue: " + step.getIdOrKey());
-        final String comment = addPanelMeta(step.getComment());
+        final String comment = step.isAuditLog() ? addPanelMeta(step.getComment())
+                                                 : step.getComment();
         response = jiraService.addComment(step.getIdOrKey(), comment);
       }
       return logResponse(response);

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/BasicJiraStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/BasicJiraStep.java
@@ -23,4 +23,8 @@ public abstract class BasicJiraStep extends Step implements Serializable {
   @Getter
   @DataBoundSetter
   private boolean failOnError = true;
+
+  @Getter
+  @DataBoundSetter
+  private boolean auditLog = true;
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditComponentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditComponentStep.java
@@ -73,8 +73,12 @@ public class EditComponentStep extends BasicJiraStep {
       if (response == null) {
         logger
             .println("JIRA: Site - " + siteName + " - Updating component: " + step.getComponent());
-        final String description = addMeta(step.getComponent().getDescription());
-        step.getComponent().setDescription(description);
+
+        if (step.isAuditLog()) {
+          final String description = addMeta(step.getComponent().getDescription());
+          step.getComponent().setDescription(description);
+        }
+
         response = jiraService.updateComponent(step.getComponent());
       }
 

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditVersionStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditVersionStep.java
@@ -72,8 +72,12 @@ public class EditVersionStep extends BasicJiraStep {
 
       if (response == null) {
         logger.println("JIRA: Site - " + siteName + " - Updating version: " + step.getVersion());
-        final String description = addMeta(step.getVersion().getDescription());
-        step.getVersion().setDescription(description);
+
+        if (step.isAuditLog()) {
+          final String description = addMeta(step.getVersion().getDescription());
+          step.getVersion().setDescription(description);
+        }
+
         response = jiraService.updateVersion(step.getVersion());
       }
 

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewComponentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewComponentStep.java
@@ -73,8 +73,12 @@ public class NewComponentStep extends BasicJiraStep {
       if (response == null) {
         logger.println(
             "JIRA: Site - " + siteName + " - Creating new component: " + step.getComponent());
-        final String description = addMeta(step.getComponent().getDescription());
-        step.getComponent().setDescription(description);
+
+        if (step.isAuditLog()) {
+          final String description = addMeta(step.getComponent().getDescription());
+          step.getComponent().setDescription(description);
+        }
+
         response = jiraService.createComponent(step.getComponent());
       }
 

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStep.java
@@ -73,7 +73,8 @@ public class NewIssueStep extends BasicJiraStep {
 
       if (response == null) {
         logger.println("JIRA: Site - " + siteName + " - Creating new issue: " + step.getIssue());
-        final String description = addPanelMeta(step.getIssue().getFields().getDescription());
+        final String description = step.isAuditLog() ? addPanelMeta(step.getIssue().getFields().getDescription())
+                                                     : step.getIssue().getFields().getDescription();
         step.getIssue().getFields().setDescription(description);
         response = jiraService.createIssue(step.getIssue());
       }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStep.java
@@ -75,7 +75,8 @@ public class NewIssuesStep extends BasicJiraStep {
       if (response == null) {
         logger.println("JIRA: Site - " + siteName + " - Creating new Issues: " + step.getIssues());
         for (IssueInput issue : step.getIssues().getIssueUpdates()) {
-          final String description = addPanelMeta(issue.getFields().getDescription());
+          final String description = step.isAuditLog() ? addPanelMeta(issue.getFields().getDescription())
+                                                       : issue.getFields().getDescription();
           issue.getFields().setDescription(description);
         }
         response = jiraService.createIssues(step.getIssues());

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewVersionStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewVersionStep.java
@@ -73,8 +73,12 @@ public class NewVersionStep extends BasicJiraStep {
       if (response == null) {
         logger
             .println("JIRA: Site - " + siteName + " - Creating new version: " + step.getVersion());
-        final String description = addMeta(step.getVersion().getDescription());
-        step.getVersion().setDescription(description);
+
+        if (step.isAuditLog()) {
+          final String description = addMeta(step.getVersion().getDescription());
+          step.getVersion().setDescription(description);
+        }
+
         response = jiraService.createVersion(step.getVersion());
       }
 


### PR DESCRIPTION
Adding the meta information in the description of the versions and components tend to add a lot of noise. I think it would be better if we can optionally remove it. Since it was a pretty straight forward  change, I decided to create the PR.

Let me know what you think and if I need to change anything.