### PR TITLE
* Make `id` type consistent across all the objects.

### DIFF
--- a/docs/pages/general/config.md
+++ b/docs/pages/general/config.md
@@ -35,10 +35,14 @@ This plugin supports both Basic and OAuth, OAuth is preferred over the Basic aut
 * `JIRA_SITE` - Global variable to set default site for all JIRA steps.
 * `JIRA_FAIL_ON_ERROR` - By default all steps `fail` the job when there is an error, by setting this to `false` all steps won't fail the job.
 
-## Error Handling.
+## Common Response & Error Handling.
 
 Every step returns a common response, which will have more information about the request like `successful`, `error`, `data` and `code`. Always try catch if we want to handle abort exception or can set `failOrError` to `false` to ignore all the error.
 
+* `successful` - Returns `true` or `false`. Status of the step.
+* `code` - HTTP code, response code returned from JIRA. or `-1` if there is any internal server error.
+* `data` - Corresponding object being returned from JIRA when request was successful. (Example jiraGetProject returns Project, jiraGetVersion returns Version and so on.)
+* `error` - Error message when the actual request to JIRA failed. Usually `code` would be `400` when there is error from JIRA or if that internal plugin error it would be `-1`.
 Example:
 
 ```groovy

--- a/docs/pages/general/release_notes.md
+++ b/docs/pages/general/release_notes.md
@@ -6,11 +6,25 @@ summary: "Change log."
 sidebar: jira_sidebar
 permalink: release_notes.html
 ---
+* ## **1.1.0**
+  * <span style="color:red">Upgrading to this version will break few existing steps, please read the following notes for more information.</span>.
+  * Multiple Fixes: [#29](https://github.com/jenkinsci/jira-steps-plugin/issues/29) Make `id` type consistent across and other minor fixes.
+    * Make `id` type consistent (to `String`) across all the objects.
+    * `jiraNewIssue` and `jiraNewIssues`
+      * Allow issue type look up by name (`fields->issuetype->name`)
+      * Allow project look up by key (`fields->project->key`)
+    * `@ToString` is duplicate in all api objects (`@Data` should take care of
+it already.)
+    * `Array` type can be just either `List` or `Set`. Changed across all objects. No need of as String[] ans more. Ex: `['a','b'] as String[]` is now just `['a', 'b']`.
+    * `fields` variable is in the wrong position for `Transitions`.
+    * Updated documentation accordingly.
+  * Added Terms and Conditions - Google Analytics. 
+
 * ## **1.0.3**
   * Fix: [#15](https://github.com/jenkinsci/jira-steps-plugin/issues/15) - Serialization error while querying component using getComponent.
   * Enhancement: [#17](https://github.com/jenkinsci/jira-steps-plugin/issues/17) - Expose access to the parent node for issue.
 * ## **1.0.2**
-  * Documentation update. No functional change. 
+  * Documentation update. No functional change.
 * ## **1.0.1**
   * Fix: [#3](https://github.com/jenkinsci/jira-steps-plugin/issues/3) - Error editing issue with existing fix version.
   * More documentation.
@@ -55,5 +69,5 @@ permalink: release_notes.html
       * jiraGetIssueLinkTypes
     * Search
       * jiraJqlSearch
-      
+
 {% include links.html %}

--- a/docs/pages/steps/jira_add_comment.md
+++ b/docs/pages/steps/jira_add_comment.md
@@ -15,12 +15,18 @@ Add comment to the given issue.
 ![Comment](https://raw.githubusercontent.com/ThoughtsLive/jira-steps/master/docs/images/jira_add_comment.png)
 
 
-## Fields
+## Input
 
 * **idOrKey** - Issue id or key.
 * **comment** - comment, supports jira wiki formatting.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -29,7 +35,7 @@ Add comment to the given issue.
   ```groovy
   node {
     stage('JIRA') {
-      jiraAddComment idOrKey: "TEST-1", comment: "test comment"
+      jiraAddComment idOrKey: 'TEST-1', comment: 'test comment'
     }
   }
   ```
@@ -39,7 +45,7 @@ Add comment to the given issue.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        jiraAddComment idOrKey: "TEST-1", comment: "test comment"
+        jiraAddComment idOrKey: 'TEST-1', comment: 'test comment'
       }
     }
   }
@@ -47,7 +53,7 @@ Add comment to the given issue.
 * Without environment variables.
 
   ```groovy
-    jiraAddComment site: "LOCAL", idOrKey: "TEST-1", comment: "test comment"
+    jiraAddComment site: 'LOCAL', idOrKey: 'TEST-1', comment: 'test comment'
   ```
 
 {% include links.html %}

--- a/docs/pages/steps/jira_add_watcher.md
+++ b/docs/pages/steps/jira_add_watcher.md
@@ -11,12 +11,18 @@ folder: steps
 
 Add userName as watcher to the given issue.
 
-## Fields
+## Input
 
 * **idOrKey** - Issue id or key.
 * **userName** - userName.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -25,7 +31,7 @@ Add userName as watcher to the given issue.
   ```groovy
   node {
     stage('JIRA') {
-      jiraAddWatcher idOrKey: "TEST-1", userName: "Jenkins"
+      jiraAddWatcher idOrKey: 'TEST-1', userName: 'Jenkins'
     }
   }
   ```
@@ -35,7 +41,7 @@ Add userName as watcher to the given issue.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        jiraAddWatcher idOrKey: "TEST-1", userName: "Jenkins"
+        jiraAddWatcher idOrKey: 'TEST-1', userName: 'Jenkins'
       }
     }
   }
@@ -43,7 +49,7 @@ Add userName as watcher to the given issue.
 * Without environment variables.
 
   ```groovy
-    jiraAddWatcher site: "LOCAL", idOrKey: "TEST-1", userName: "Jenkins"
+    jiraAddWatcher site: 'LOCAL', idOrKey: 'TEST-1', userName: 'Jenkins'
   ```
 
 {% include links.html %}

--- a/docs/pages/steps/jira_assign_issue.md
+++ b/docs/pages/steps/jira_assign_issue.md
@@ -12,12 +12,18 @@ folder: steps
 
 Assign issue to given user.
 
-## Fields
+## Input
 
 * **idOrKey** - Issue id or key.
 * **userName** - user.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -26,7 +32,7 @@ Assign issue to given user.
   ```groovy
   node {
     stage('JIRA') {
-      jiraAssignIssue idOrKey: "TEST-1", userName: "Jenkins"
+      jiraAssignIssue idOrKey: 'TEST-1', userName: 'Jenkins'
     }
   }
   ```
@@ -36,7 +42,7 @@ Assign issue to given user.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        jiraAssignIssue idOrKey: "TEST-1", userName: "Jenkins"
+        jiraAssignIssue idOrKey: 'TEST-1', userName: 'Jenkins'
       }
     }
   }
@@ -44,7 +50,7 @@ Assign issue to given user.
 * Without environment variables.
 
   ```groovy
-    jiraAssignIssue site: "LOCAL", idOrKey: "TEST-1", userName: "Jenkins"
+    jiraAssignIssue site: 'LOCAL', idOrKey: 'TEST-1', userName: 'Jenkins'
   ```
 
 {% include links.html %}

--- a/docs/pages/steps/jira_edit_comment.md
+++ b/docs/pages/steps/jira_edit_comment.md
@@ -11,13 +11,19 @@ folder: steps
 
 Edit comment on an issue by given comment id.
 
-## Fields
+## Input
 
 * **idOrKey** - Issue id or key.
 * **commentId** - comment id.
 * **comment** - comment, supports jira wiki formatting.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -26,7 +32,7 @@ Edit comment on an issue by given comment id.
   ```groovy
   node {
     stage('JIRA') {
-      jiraEditComment idOrKey: "TEST-1", commentId: "1000", comment: "test comment"
+      jiraEditComment idOrKey: 'TEST-1', commentId: '1000', comment: 'test comment'
     }
   }
   ```
@@ -36,7 +42,7 @@ Edit comment on an issue by given comment id.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        jiraEditComment idOrKey: "TEST-1", commentId: "1000", comment: "test comment"
+        jiraEditComment idOrKey: 'TEST-1', commentId: '1000', comment: 'test comment'
       }
     }
   }
@@ -44,7 +50,7 @@ Edit comment on an issue by given comment id.
 * Without environment variables.
 
   ```groovy
-    jiraEditComment site: "LOCAL", idOrKey: "TEST-1", commentId: "1000", comment: "test comment"
+    jiraEditComment site: 'LOCAL', idOrKey: 'TEST-1', commentId: '1000', comment: 'test comment'
   ```
 
 {% include links.html %}

--- a/docs/pages/steps/jira_edit_component.md
+++ b/docs/pages/steps/jira_edit_component.md
@@ -14,11 +14,17 @@ Edit component based on given input, which should have some minimal information 
 
 Note: Sometimes it may not possible to directly edit component (rename it) without un tagging all of its current JIRAs.
 
-## Fields
+## Input
 
 * **component** - component to be edited.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -27,7 +33,7 @@ Note: Sometimes it may not possible to directly edit component (rename it) witho
   ```groovy
   node {
     stage('JIRA') {
-      def testComponent = [ id: 1000,
+      def testComponent = [ id: "1000",
                             name: "test-component",
                             description: "desc",
                             project: "TEST" ]
@@ -41,7 +47,7 @@ Note: Sometimes it may not possible to directly edit component (rename it) witho
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        def testComponent = [ id: 1000,
+        def testComponent = [ id: "1000",
                               name: "test-component",
                               description: "desc",
                               project: "TEST" ]
@@ -53,7 +59,7 @@ Note: Sometimes it may not possible to directly edit component (rename it) witho
 * Without environment variables.
 
   ```groovy
-    def testComponent = [ id: 1000,
+    def testComponent = [ id: "1000",
                           name: "test-component",
                           description: "desc",
                           project: "TEST" ]

--- a/docs/pages/steps/jira_edit_issue.md
+++ b/docs/pages/steps/jira_edit_issue.md
@@ -12,12 +12,22 @@ folder: steps
 
 Updates an existing issue based on given input, which should have some minimal information on that object.
 
-## Fields
+## Input
 
 * **idOrKey** - issue id or key.
 * **issue** - issue to be created.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+#### Notes:
+
+* Edit issue only support few fields as input for now. Please refer to the [DTO](https://github.com/jenkinsci/jira-steps-plugin/blob/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/FieldsInput.java) for more information.
+
+* For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -27,18 +37,21 @@ Updates an existing issue based on given input, which should have some minimal i
   node {
     stage('JIRA') {
       # Look at IssueInput class for more information.
-      def testIssue = [fields: [ project: [id: 10000],
-                                 summary: "New JIRA Created from Jenkins.",
-                                 description: "New JIRA Created from Jenkins.",
-                                 issuetype: [id: 3]]]
+      def testIssue = [fields: [ // id or key must present for project.
+                                 project: [id: '10000'],
+                                 summary: 'New JIRA Created from Jenkins.',
+                                 description: 'New JIRA Created from Jenkins.',
+                                 // id or name must present for issuetype.
+                                 issuetype: [id: '3']]]
 
-      response = jiraEditIssue idOrKey: "TEST-01", issue: testIssue
+      response = jiraEditIssue idOrKey: 'TEST-01', issue: testIssue
 
       echo response.successful.toString()
       echo response.data.toString()
     }
   }
   ```
+
 * `withEnv` to override the default site (or if there is not global site)
 
   ```groovy
@@ -46,12 +59,12 @@ Updates an existing issue based on given input, which should have some minimal i
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
         # Look at IssueInput class for more information.
-        def testIssue = [fields: [ project: [id: 10000],
-                                   summary: "New JIRA Created from Jenkins.",
-                                   description: "New JIRA Created from Jenkins.",
-                                   issuetype: [id: 3]]]
+        def testIssue = [fields: [ project: [id: '10000'],
+                                   summary: 'New JIRA Created from Jenkins.',
+                                   description: 'New JIRA Created from Jenkins.',
+                                   issuetype: [id: '3']]]
 
-        response = jiraEditIssue idOrKey: "TEST-01", issue: testIssue
+        response = jiraEditIssue idOrKey: 'TEST-01', issue: testIssue
 
         echo response.successful.toString()
         echo response.data.toString()
@@ -63,12 +76,12 @@ Updates an existing issue based on given input, which should have some minimal i
 
   ```groovy
   # Look at IssueInput class for more information.
-  def testIssue = [fields: [ project: [id: 10000],
-                             summary: "New JIRA Created from Jenkins.",
-                             description: "New JIRA Created from Jenkins.",
-                             issuetype: [id: 3]]]
+  def testIssue = [fields: [ project: [id: '10000'],
+                             summary: 'New JIRA Created from Jenkins.',
+                             description: 'New JIRA Created from Jenkins.',
+                             issuetype: [id: '3']]]
 
-  response = jiraEditIssue idOrKey: "TEST-01", issue: testIssue, site: "LOCAL"
+  response = jiraEditIssue idOrKey: 'TEST-01', issue: testIssue, site: 'LOCAL'
 
   echo response.successful.toString()
   echo response.data.toString()

--- a/docs/pages/steps/jira_edit_version.md
+++ b/docs/pages/steps/jira_edit_version.md
@@ -16,11 +16,17 @@ Note: Sometimes it may not possible to directly edit version (rename it) without
 
 TODO: probably we should try move version
 
-## Fields
+## Input
 
 * **version** - version to be edited.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -29,12 +35,12 @@ TODO: probably we should try move version
   ```groovy
   node {
     stage('JIRA') {
-      def testVersion = [ id: 1000,
-                          name: "test-version",
+      def testVersion = [ id: '1000',
+                          name: 'test-version',
                           archived: true,
                           released: true,
-                          description: "desc",
-                          project: "TEST" ]
+                          description: 'desc',
+                          project: 'TEST' ]
       jiraEditVersion version: testVersion
     }
   }
@@ -45,12 +51,12 @@ TODO: probably we should try move version
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        def testVersion = [ id: 1000,
-                            name: "test-version",
+        def testVersion = [ id: '1000',
+                            name: 'test-version',
                             archived: true,
                             released: true,
-                            description: "desc",
-                            project: "TEST" ]
+                            description: 'desc',
+                            project: 'TEST' ]
         jiraEditVersion version: testVersion
       }
     }
@@ -59,13 +65,13 @@ TODO: probably we should try move version
 * Without environment variables.
 
   ```groovy
-    def testVersion = [ id: 1000,
-                        name: "test-version",
+    def testVersion = [ id: '1000',
+                        name: 'test-version',
                         archived: true,
                         released: true,
-                        description: "desc",
-                        project: "TEST" ]
-    jiraEditVersion version: testVersion, site: "LOCAL"
+                        description: 'desc',
+                        project: 'TEST' ]
+    jiraEditVersion version: testVersion, site: 'LOCAL'
   ```
 
 {% include links.html %}

--- a/docs/pages/steps/jira_get_comment.md
+++ b/docs/pages/steps/jira_get_comment.md
@@ -12,12 +12,18 @@ folder: steps
 
 Get comment of the given issue by id.
 
-## Fields
+## Input
 
 * **idOrKey** - Issue id or key.
 * **commentId** - commentId.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -26,7 +32,7 @@ Get comment of the given issue by id.
   ```groovy
   node {
     stage('JIRA') {
-      def comment = jiraGetComment idOrKey: "TEST-1", commentId: 10004
+      def comment = jiraGetComment idOrKey: 'TEST-1', commentId: '10004'
       echo comment.data.toString()
     }
   }
@@ -37,7 +43,7 @@ Get comment of the given issue by id.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        def comment = jiraGetComment idOrKey: "TEST-1", commentId: 10004
+        def comment = jiraGetComment idOrKey: 'TEST-1', commentId: '10004'
         echo comment.data.toString()
       }
     }
@@ -46,7 +52,7 @@ Get comment of the given issue by id.
 * Without environment variables.
 
   ```groovy
-    def comment = jiraGetComment site: "LOCAL", idOrKey: "TEST-1", commentId: 10004
+    def comment = jiraGetComment site: 'LOCAL', idOrKey: 'TEST-1', commentId: '10004'
     echo comment.data.toString()
   ```
 

--- a/docs/pages/steps/jira_get_comments.md
+++ b/docs/pages/steps/jira_get_comments.md
@@ -12,11 +12,17 @@ folder: steps
 
 Get all comments of the given issue.
 
-## Fields
+## Input
 
 * **idOrKey** - Issue id or key.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -25,7 +31,7 @@ Get all comments of the given issue.
   ```groovy
   node {
     stage('JIRA') {
-      def comments = jiraGetComments idOrKey: "TEST-1"
+      def comments = jiraGetComments idOrKey: 'TEST-1'
       echo comments.data.toString()
     }
   }
@@ -36,7 +42,7 @@ Get all comments of the given issue.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        def comments = jiraGetComments idOrKey: "TEST-1"
+        def comments = jiraGetComments idOrKey: 'TEST-1'
         echo comments.data.toString()
       }
     }
@@ -45,7 +51,7 @@ Get all comments of the given issue.
 * Without environment variables.
 
   ```groovy
-    def comments = jiraGetComments site: "LOCAL", idOrKey: "TEST-1"
+    def comments = jiraGetComments site: 'LOCAL', idOrKey: 'TEST-1'
     echo comments.data.toString()
   ```
 

--- a/docs/pages/steps/jira_get_component.md
+++ b/docs/pages/steps/jira_get_component.md
@@ -12,11 +12,17 @@ folder: steps
 
 Get component by id.
 
-## Fields
+## Input
 
 * **id** - componentId.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -45,7 +51,7 @@ Get component by id.
 * Without environment variables.
 
   ```groovy
-    def component = jiraGetComponent site: "LOCAL", id: 10024, failOnError: false
+    def component = jiraGetComponent site: 'LOCAL', id: '10024', failOnError: false
     echo component.data.toString()
   ```
 

--- a/docs/pages/steps/jira_get_component_issue_count.md
+++ b/docs/pages/steps/jira_get_component_issue_count.md
@@ -12,11 +12,17 @@ folder: steps
 
 Get component issue count by id.
 
-## Fields
+## Input
 
 * **id** - componentId.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -45,7 +51,7 @@ Get component issue count by id.
 * Without environment variables.
 
   ```groovy
-    def count = jiraGetComponentIssueCount site: "LOCAL", id: 10024, failOnError: false
+    def count = jiraGetComponentIssueCount site: 'LOCAL', id: '10024', failOnError: false
     echo count.data.toString()
   ```
 {% include links.html %}

--- a/docs/pages/steps/jira_get_issue.md
+++ b/docs/pages/steps/jira_get_issue.md
@@ -12,11 +12,17 @@ folder: steps
 
 Get issue by id or key.
 
-## Fields
+## Input
 
 * **idOrKey** - Issue id or key.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -25,7 +31,7 @@ Get issue by id or key.
   ```groovy
   node {
     stage('JIRA') {
-      def issue = jiraGetIssue idOrKey: "TEST-1"
+      def issue = jiraGetIssue idOrKey: 'TEST-1'
       echo issue.data.toString()
     }
   }
@@ -36,7 +42,7 @@ Get issue by id or key.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        def issue = jiraGetIssue idOrKey: "TEST-1"
+        def issue = jiraGetIssue idOrKey: 'TEST-1'
         echo issue.data.toString()
       }
     }
@@ -45,7 +51,7 @@ Get issue by id or key.
 * Without environment variables.
 
   ```groovy
-    def issue = jiraGetIssue idOrKey: "TEST-1", site: "LOCAL"
+    def issue = jiraGetIssue idOrKey: 'TEST-1', site: 'LOCAL'
     echo issue.data.toString()
   ```
 

--- a/docs/pages/steps/jira_get_issue_link_types.md
+++ b/docs/pages/steps/jira_get_issue_link_types.md
@@ -12,10 +12,16 @@ folder: steps
 
 Get all issue links types.
 
-## Fields
+## Input
 
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -44,7 +50,7 @@ Get all issue links types.
 * Without environment variables.
 
   ```groovy
-    def issueLinkTypes = jiraGetIssueLinkTypes site: "LOCAL", failOnError: false
+    def issueLinkTypes = jiraGetIssueLinkTypes site: 'LOCAL', failOnError: false
     echo issueLinkTypes.data.toString()
   ```
 

--- a/docs/pages/steps/jira_get_issue_transitions.md
+++ b/docs/pages/steps/jira_get_issue_transitions.md
@@ -12,11 +12,17 @@ folder: steps
 
 Get all transitions of the given issue.
 
-## Fields
+## Input
 
 * **idOrKey** - Issue id or key.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -25,7 +31,7 @@ Get all transitions of the given issue.
   ```groovy
   node {
     stage('JIRA') {
-      def transitions = jiraGetIssueTransitions idOrKey: "TEST-1"
+      def transitions = jiraGetIssueTransitions idOrKey: 'TEST-1'
       echo transitions.data.toString()
     }
   }
@@ -36,7 +42,7 @@ Get all transitions of the given issue.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        def transitions = jiraGetIssueTransitions idOrKey: "TEST-1"
+        def transitions = jiraGetIssueTransitions idOrKey: 'TEST-1'
         echo transitions.data.toString()
       }
     }
@@ -45,7 +51,7 @@ Get all transitions of the given issue.
 * Without environment variables.
 
   ```groovy
-    def transitions = jiraGetIssueTransitions idOrKey: "TEST-1"
+    def transitions = jiraGetIssueTransitions idOrKey: 'TEST-1'
     echo transitions.data.toString()
   ```
 

--- a/docs/pages/steps/jira_get_issue_watches.md
+++ b/docs/pages/steps/jira_get_issue_watches.md
@@ -12,11 +12,17 @@ folder: steps
 
 Get all issue watchers.
 
-## Fields
+## Input
 
 * **idOrKey** - Issue id or key.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -25,7 +31,7 @@ Get all issue watchers.
   ```groovy
   node {
     stage('JIRA') {
-      def watches = jiraGetIssueWatches idOrKey: "TEST-1"
+      def watches = jiraGetIssueWatches idOrKey: 'TEST-1'
       echo watches.data.toString()
     }
   }
@@ -36,7 +42,7 @@ Get all issue watchers.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        def watches = jiraGetIssueWatches idOrKey: "TEST-1"
+        def watches = jiraGetIssueWatches idOrKey: 'TEST-1'
         echo watches.data.toString()
       }
     }
@@ -45,7 +51,7 @@ Get all issue watchers.
 * Without environment variables.
 
   ```groovy
-    def watches = jiraGetIssueWatches idOrKey: "TEST-1", site: "LOCAL"
+    def watches = jiraGetIssueWatches idOrKey: 'TEST-1', site: 'LOCAL'
     echo watches.data.toString()
   ```
 

--- a/docs/pages/steps/jira_get_project.md
+++ b/docs/pages/steps/jira_get_project.md
@@ -12,11 +12,17 @@ folder: steps
 
 Query project info by id or key.
 
-## Fields
+## Input
 
 * **idOrKey** - project id or key.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -25,7 +31,7 @@ Query project info by id or key.
   ```groovy
   node {
     stage('JIRA') {
-      def project = jiraGetProject idOrKey: "TEST"
+      def project = jiraGetProject idOrKey: 'TEST'
       echo project.data.toString()
     }
   }
@@ -36,7 +42,7 @@ Query project info by id or key.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        def project = jiraGetProject idOrKey: "TEST"
+        def project = jiraGetProject idOrKey: 'TEST'
         echo project.data.toString()
       }
     }
@@ -45,7 +51,7 @@ Query project info by id or key.
 * Without environment variables.
 
   ```groovy
-    def project = jiraGetProject idOrKey: "TEST", site: "LOCAL"
+    def project = jiraGetProject idOrKey: 'TEST', site: 'LOCAL'
     echo project.data.toString()
   ```
 

--- a/docs/pages/steps/jira_get_projects.md
+++ b/docs/pages/steps/jira_get_projects.md
@@ -12,10 +12,16 @@ folder: steps
 
 Query all projects in the given site.
 
-## Fields
+## Input
 
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -44,7 +50,7 @@ Query all projects in the given site.
 * Without environment variables.
 
   ```groovy
-    def projects = jiraGetProjects()
+    def projects = jiraGetProjects(), site: 'LOCAL'
     echo project.data.toString()
   ```
 

--- a/docs/pages/steps/jira_get_version.md
+++ b/docs/pages/steps/jira_get_version.md
@@ -12,11 +12,17 @@ folder: steps
 
 Query version by id.
 
-## Fields
+## Input
 
 * **id** - version id.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -45,7 +51,7 @@ Query version by id.
 * Without environment variables.
 
   ```groovy
-    def version = jiraGetVersion id: '10000', site: "LOCAL", failOnError: false
+    def version = jiraGetVersion id: '10000', site: 'LOCAL', failOnError: false
     echo version.data.toString()
   ```
 

--- a/docs/pages/steps/jira_jql_search.md
+++ b/docs/pages/steps/jira_jql_search.md
@@ -12,11 +12,17 @@ folder: steps
 
 Search Issues by Jql.
 
-## Fields
+## Input
 
 * **jql** - jql as a string.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -25,7 +31,7 @@ Search Issues by Jql.
   ```groovy
   node {
     stage('JIRA') {
-      def issues = jiraJqlSearch jql: "PROJECT = TEST"
+      def issues = jiraJqlSearch jql: 'PROJECT = TEST'
       echo issues.data.toString()
     }
   }
@@ -36,7 +42,7 @@ Search Issues by Jql.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        def issues = jiraJqlSearch jql: "PROJECT = TEST"
+        def issues = jiraJqlSearch jql: 'PROJECT = TEST'
         echo issues.data.toString()
       }
     }
@@ -45,7 +51,7 @@ Search Issues by Jql.
 * Without environment variables.
 
   ```groovy
-    def issues = jiraJqlSearch jql: "PROJECT = TEST", site: "LOCAL", failOnError: true
+    def issues = jiraJqlSearch jql: 'PROJECT = TEST', site: 'LOCAL', failOnError: true
     echo issues.data.toString()
   ```
 

--- a/docs/pages/steps/jira_link_issues.md
+++ b/docs/pages/steps/jira_link_issues.md
@@ -14,13 +14,19 @@ Link two issues.
 
 Hint: Try getIssueLinkTypes to know the type.
 
-## Fields
+## Input
 
 * **type** - type of the link. (Ex: Relates, Blocks, Cloners, Duplicate)
 * **inwardKey** - inward issue key.
 * **outwardKey** - outward issue key.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -29,7 +35,7 @@ Hint: Try getIssueLinkTypes to know the type.
   ```groovy
   node {
     stage('JIRA') {
-      jiraLinkIssues type: "Relates", inwardKey: "TEST-1", outwardKey: "TEST-2"
+      jiraLinkIssues type: 'Relates', inwardKey: 'TEST-1', outwardKey: 'TEST-2'
     }
   }
   ```
@@ -39,7 +45,7 @@ Hint: Try getIssueLinkTypes to know the type.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        jiraLinkIssues type: "Relates", inwardKey: "TEST-1", outwardKey: "TEST-2"
+        jiraLinkIssues type: 'Relates', inwardKey: 'TEST-1', outwardKey: 'TEST-2'
       }
     }
   }
@@ -47,7 +53,7 @@ Hint: Try getIssueLinkTypes to know the type.
 * Without environment variables.
 
   ```groovy
-    jiraLinkIssues type: "Relates", inwardKey: "TEST-1", outwardKey: "TEST-2", site: "LOCAL"
+    jiraLinkIssues type: 'Relates', inwardKey: 'TEST-1', outwardKey: 'TEST-2', site: 'LOCAL'
   ```
 
 {% include links.html %}

--- a/docs/pages/steps/jira_new_component.md
+++ b/docs/pages/steps/jira_new_component.md
@@ -14,11 +14,17 @@ Create new component based on given input, which should have some minimal inform
 
 ![New Component](https://raw.githubusercontent.com/ThoughtsLive/jira-steps/master/docs/images/jira_new_component.png)
 
-## Fields
+## Input
 
 * **component** - component to be created.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -27,9 +33,9 @@ Create new component based on given input, which should have some minimal inform
   ```groovy
   node {
     stage('JIRA') {
-      def testComponent = [ name: "test-component",
-                            description: "desc",
-                            project: "TEST" ]
+      def testComponent = [ name: 'test-component',
+                            description: 'desc',
+                            project: 'TEST' ]
       jiraNewComponent component: testComponent
     }
   }
@@ -40,9 +46,9 @@ Create new component based on given input, which should have some minimal inform
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        def testComponent = [ name: "test-component",
-                              description: "desc",
-                              project: "TEST" ]
+        def testComponent = [ name: 'test-component',
+                              description: 'desc',
+                              project: 'TEST' ]
         jiraNewComponent component: testComponent
       }
     }
@@ -51,9 +57,9 @@ Create new component based on given input, which should have some minimal inform
 * Without environment variables.
 
   ```groovy
-    def testComponent = [ name: "test-component",
-                          description: "desc",
-                          project: "TEST" ]
+    def testComponent = [ name: 'test-component',
+                          description: 'desc',
+                          project: 'TEST' ]
     jiraNewComponent component: testComponent
   ```
 

--- a/docs/pages/steps/jira_new_issue.md
+++ b/docs/pages/steps/jira_new_issue.md
@@ -14,11 +14,17 @@ Creates new issue based on given input, which should have some minimal informati
 
 ![New Issue](https://raw.githubusercontent.com/ThoughtsLive/jira-steps/master/docs/images/jira_new_issue.png)
 
-## Fields
+## Input
 
 * **issue** - issue to be created.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -28,10 +34,12 @@ Creates new issue based on given input, which should have some minimal informati
   node {
     stage('JIRA') {
       # Look at IssueInput class for more information.
-      def testIssue = [fields: [ project: [id: '10000'],
-                           summary: "New JIRA Created from Jenkins.",
-                           description: "New JIRA Created from Jenkins.",
-                           issuetype: [id: 3]]]
+      def testIssue = [fields: [ // id or key must present for project.
+                                 project: [id: '10000'],
+                                 summary: 'New JIRA Created from Jenkins.',
+                                 description: 'New JIRA Created from Jenkins.',
+                                 // id or name must present for issueType.
+                                 issuetype: [id: '3']]]
 
       response = jiraNewIssue issue: testIssue
 
@@ -47,9 +55,9 @@ Creates new issue based on given input, which should have some minimal informati
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
         def testIssue = [fields: [ project: [id: '10000'],
-                             summary: "New JIRA Created from Jenkins.",
-                             description: "New JIRA Created from Jenkins.",
-                             issuetype: [id: 3]]]
+                                   summary: 'New JIRA Created from Jenkins.',
+                                   description: 'New JIRA Created from Jenkins.',
+                                   issuetype: [id: '3']]]
 
         response = jiraNewIssue issue: testIssue
 
@@ -63,11 +71,11 @@ Creates new issue based on given input, which should have some minimal informati
 
   ```groovy
   def testIssue = [fields: [ project: [id: '10000'],
-                       summary: "New JIRA Created from Jenkins.",
-                       description: "New JIRA Created from Jenkins.",
-                       issuetype: [id: 3]]]
+                             summary: 'New JIRA Created from Jenkins.',
+                             description: 'New JIRA Created from Jenkins.',
+                             issuetype: [id: '3']]]
 
-  response = jiraNewIssue issue: testIssue, site: "LOCAL"
+  response = jiraNewIssue issue: testIssue, site: 'LOCAL'
 
   echo response.successful.toString()
   echo response.data.toString()

--- a/docs/pages/steps/jira_new_issues.md
+++ b/docs/pages/steps/jira_new_issues.md
@@ -12,11 +12,17 @@ folder: steps
 
 Creates issues in bulk.
 
-## Fields
+## Input
 
 * **issues** - issues to be created.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -27,14 +33,14 @@ Creates issues in bulk.
     stage('JIRA') {
       # Look at IssueInput class for more information.
       def testIssue1 = [fields: [ project: [id: '10000'],
-                           summary: "New JIRA Created from Jenkins.",
-                           description: "New JIRA Created from Jenkins.",
-                           issuetype: [id: '3']]]
+                                  summary: 'New JIRA Created from Jenkins.',
+                                  description: 'New JIRA Created from Jenkins.',
+                                  issuetype: [id: '3']]]
 
 
       def testIssue2 = [fields: [ project: [id: '10000'],
-                                  summary: "New JIRA Created from Jenkins.",
-                                  description: "New JIRA Created from Jenkins.",
+                                  summary: 'New JIRA Created from Jenkins.',
+                                  description: 'New JIRA Created from Jenkins.',
                                   issuetype: [id: '3']]]
 
       def testIssues = [issueUpdates: [testIssue1, testIssue2]]
@@ -54,14 +60,14 @@ Creates issues in bulk.
       withEnv(['JIRA_SITE=LOCAL']) {
         # Look at IssueInput class for more information.
         def testIssue1 = [fields: [ project: [id: '10000'],
-                             summary: "New JIRA Created from Jenkins.",
-                             description: "New JIRA Created from Jenkins.",
-                             issuetype: [id: 3]]]
+                                    summary: 'New JIRA Created from Jenkins.',
+                                    description: 'New JIRA Created from Jenkins.',
+                                    issuetype: [id: '3']]]
 
 
         def testIssue2 = [fields: [ project: [id: '10000'],
-                                    summary: "New JIRA Created from Jenkins.",
-                                    description: "New JIRA Created from Jenkins.",
+                                    summary: 'New JIRA Created from Jenkins.',
+                                    description: 'New JIRA Created from Jenkins.',
                                     issuetype: [id: '3']]]
 
         def testIssues = [issueUpdates: [testIssue1, testIssue2]]
@@ -79,18 +85,18 @@ Creates issues in bulk.
   ```groovy
   # Look at IssueInput class for more information.
   def testIssue1 = [fields: [ project: [id: '10000'],
-                       summary: "New JIRA Created from Jenkins.",
-                       issuetype: [id: '3']]]
+                              summary: 'New JIRA Created from Jenkins.',
+                              issuetype: [id: '3']]]
 
 
   def testIssue2 = [fields: [ project: [id: '10000'],
-                              summary: "New JIRA Created from Jenkins.",
-                              description: "New JIRA Created from Jenkins.",
+                              summary: 'New JIRA Created from Jenkins.',
+                              description: 'New JIRA Created from Jenkins.',
                               issuetype: [id: '3']]]
 
   def testIssues = [issueUpdates: [testIssue1, testIssue2]]
 
-  response = jiraNewIssues issues: testIssues, site: "LOCAL"
+  response = jiraNewIssues issues: testIssues, site: 'LOCAL'
 
   echo response.successful.toString()
   echo response.data.toString()

--- a/docs/pages/steps/jira_new_version.md
+++ b/docs/pages/steps/jira_new_version.md
@@ -12,11 +12,17 @@ folder: steps
 
 Creates new version based on given input, which should have some minimal information on that object.
 
-## Fields
+## Input
 
 * **version** - version to be created.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -25,11 +31,11 @@ Creates new version based on given input, which should have some minimal informa
   ```groovy
   node {
     stage('JIRA') {
-      def testVersion = [ name: "test-version",
+      def testVersion = [ name: 'test-version',
                           archived: true,
                           released: true,
-                          description: "desc",
-                          project: "TEST" ]
+                          description: 'desc',
+                          project: 'TEST' ]
       jiraNewVersion version: testVersion
     }
   }
@@ -40,11 +46,11 @@ Creates new version based on given input, which should have some minimal informa
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        def testVersion = [ name: "test-version",
+        def testVersion = [ name: 'test-version',
                             archived: true,
                             released: true,
-                            description: "desc",
-                            project: "TEST" ]
+                            description: 'desc',
+                            project: 'TEST' ]
         jiraNewVersion version: testVersion
       }
     }
@@ -53,12 +59,12 @@ Creates new version based on given input, which should have some minimal informa
 * Without environment variables.
 
   ```groovy
-    def testVersion = [ name: "test-version",
+    def testVersion = [ name: 'test-version',
                         archived: true,
                         released: true,
-                        description: "desc",
-                        project: "TEST" ]
-    jiraNewVersion version: testVersion, site: "LOCAL"
+                        description: 'desc',
+                        project: 'TEST' ]
+    jiraNewVersion version: testVersion, site: 'LOCAL'
   ```
 
 {% include links.html %}

--- a/docs/pages/steps/jira_notify_issue.md
+++ b/docs/pages/steps/jira_notify_issue.md
@@ -12,12 +12,18 @@ folder: steps
 
 Notify users (like watchers, assignee and so on..) of issue.
 
-## Fields
+## Input
 
 * **idOrKey** - Issue id or key.
 * **notify** - more info about whom should we notify and so on.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -26,22 +32,22 @@ Notify users (like watchers, assignee and so on..) of issue.
   ```groovy
   node {
     stage('JIRA') {
-      def notify = [ subject: "Update about TEST-01",
-                     textBody: "Just wanted to update about this issue...",
-                     htmlBody: "Just wanted to update about this issue...",
+      def notify = [ subject: 'Update about TEST-01',
+                     textBody: 'Just wanted to update about this issue...',
+                     htmlBody: 'Just wanted to update about this issue...',
                      to: [ reporter: true,
                            assignee: true,
                            watchers: false,
                            voters: false,
                            users: [{
-                                    "name": "rao",
+                                    name: 'rao',
                                   },
                                   {
-                                    "name": "naresh",
+                                    name: 'naresh',
                                   }]
                         ]
                     ]
-      jiraNotifyIssue idOrKey: "TEST-1", notify: notify
+      jiraNotifyIssue idOrKey: 'TEST-1', notify: notify
     }
   }
   ```
@@ -51,22 +57,22 @@ Notify users (like watchers, assignee and so on..) of issue.
   node {
     stage('JIRA') {
       withEnv(['JIRA_SITE=LOCAL']) {
-        def notify = [ subject: "Update about TEST-01",
-                       textBody: "Just wanted to update about this issue...",
-                       htmlBody: "Just wanted to update about this issue...",
+        def notify = [ subject: 'Update about TEST-01',
+                       textBody: 'Just wanted to update about this issue...',
+                       htmlBody: 'Just wanted to update about this issue...',
                        to: [ reporter: true,
                              assignee: true,
                              watchers: false,
                              voters: false,
                              users: [{
-                                      "name": "rao",
+                                      name: 'rao',
                                     },
                                     {
-                                      "name": "naresh",
+                                      name: 'naresh',
                                     }]
                           ]
                       ]
-        jiraNotifyIssue idOrKey: "TEST-1", notify: notify
+        jiraNotifyIssue idOrKey: 'TEST-1', notify: notify
       }
     }
   }
@@ -74,22 +80,22 @@ Notify users (like watchers, assignee and so on..) of issue.
 * Without environment variables.
 
   ```groovy
-    def notify = [ subject: "Update about TEST-01",
-                   textBody: "Just wanted to update about this issue...",
-                   htmlBody: "Just wanted to update about this issue...",
+    def notify = [ subject: 'Update about TEST-01',
+                   textBody: 'Just wanted to update about this issue...',
+                   htmlBody: 'Just wanted to update about this issue...',
                    to: [ reporter: true,
                          assignee: true,
                          watchers: false,
                          voters: false,
                          users: [{
-                                  "name": "rao",
+                                  name: 'rao',
                                 },
                                 {
-                                  "name": "naresh",
+                                  name: 'naresh',
                                 }]
                        ]
                   ]
-    jiraNotifyIssue idOrKey: "TEST-1", notify: notify, site: "LOCAL"
+    jiraNotifyIssue idOrKey: 'TEST-1', notify: notify, site: 'LOCAL'
   ```
 
 {% include links.html %}

--- a/docs/pages/steps/jira_transition_issue.md
+++ b/docs/pages/steps/jira_transition_issue.md
@@ -12,12 +12,18 @@ folder: steps
 
 Transition issue to different state.
 
-## Fields
+## Input
 
 * **idOrKey** - Issue id or key.
 * **input** - comment, supports jira wiki formatting.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
+
+Note: For more information about input, please refer to the model objects in the [api](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+
+## Output
+
+Each step generates generic output, please refer to this [link](config.html#common-response--error-handling) for more information.
 
 ## Examples
 
@@ -28,29 +34,29 @@ Transition issue to different state.
     stage('JIRA') {
       def transitionInput =
       [
-          "update": [
-              "comment": [
+          update: [
+              comment: [
                   [
-                      "add": [
-                          "body": "Bug has been fixed."
+                      add: [
+                          body: 'Bug has been fixed.'
                       ]
                   ]
               ]
           ],
-          "transition": [
-              "id": "5",
-              "fields": [
-                  "assignee": [
-                      "name": "bob"
+          transition: [
+              id: '5',
+              fields: [
+                  assignee: [
+                      name: 'bob'
                   },
-                  "resolution": [
-                      "name": "Fixed"
+                  resolution: [
+                      name: 'Fixed'
                   ]
               ]
           ]
       ]
 
-      jiraTransitionIssue idOrKey: "TEST-1", input: transitionInput
+      jiraTransitionIssue idOrKey: 'TEST-1', input: transitionInput
     }
   }
   ```
@@ -62,29 +68,29 @@ Transition issue to different state.
       withEnv(['JIRA_SITE=LOCAL']) {
         def transitionInput =
         [
-            "update": [
-                "comment": [
+            update: [
+                comment: [
                     [
-                        "add": [
-                            "body": "Bug has been fixed."
+                        add: [
+                            body: 'Bug has been fixed.'
                         ]
                     ]
                 ]
             ],
-            "transition": [
-                "id": "5",
-                "fields": [
-                    "assignee": [
-                        "name": "bob"
+            transition: [
+                id: '5',
+                fields: [
+                    assignee: [
+                        name: 'bob'
                     },
-                    "resolution": [
-                        "name": "Fixed"
+                    resolution: [
+                        name: 'Fixed'
                     ]
                 ]
             ]
         ]
 
-        jiraTransitionIssue idOrKey: "TEST-1", input: transitionInput
+        jiraTransitionIssue idOrKey: 'TEST-1', input: transitionInput
       }
     }
   }
@@ -94,29 +100,29 @@ Transition issue to different state.
   ```groovy
         def transitionInput =
         [
-            "update": [
-                "comment": [
+            update: [
+                comment: [
                     [
-                        "add": [
-                            "body": "Bug has been fixed."
+                        add: [
+                            body: 'Bug has been fixed.'
                         ]
                     ]
                 ]
             ],
-            "transition": [
-                "id": "5",
-                "fields": [
-                    "assignee": [
-                        "name": "bob"
+            transition: [
+                id: '5',
+                fields: [
+                    assignee: [
+                        name: 'bob'
                     },
-                    "resolution": [
-                        "name": "Fixed"
+                    resolution: [
+                        name: 'Fixed'
                     ]
                 ]
             ]
         ]
 
-        jiraTransitionIssue idOrKey: "TEST-1", input: transitionInput, site: "LOCAL"
+        jiraTransitionIssue idOrKey: 'TEST-1', input: transitionInput, site: 'LOCAL'
   ```
 
 {% include links.html %}

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Attachment.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Attachment.java
@@ -14,10 +14,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Comment.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Comment.java
@@ -14,10 +14,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Comments.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Comments.java
@@ -14,10 +14,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Component.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Component.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Count.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Count.java
@@ -12,10 +12,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/EmailTo.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/EmailTo.java
@@ -14,10 +14,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Field.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Field.java
@@ -12,10 +12,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
@@ -30,7 +28,7 @@ public class Field implements Serializable {
   }
 
   @JsonProperty("id")
-  private int id;
+  private String id;
 
   @JsonProperty("name")
   private String name;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Fields.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Fields.java
@@ -17,10 +17,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Group.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Group.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Issue.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Issue.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/IssueLink.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/IssueLink.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/IssueLinkType.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/IssueLinkType.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/IssueLinkTypes.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/IssueLinkTypes.java
@@ -2,6 +2,7 @@
 package org.thoughtslive.jenkins.plugins.jira.api;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -9,25 +10,21 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@SuppressFBWarnings
 @Builder
 public class IssueLinkTypes implements Serializable {
 
   private static final long serialVersionUID = -1703145974228772260L;
 
   @JsonProperty("issueLinkTypes")
-  private IssueLinkType[] issueLinkTypes;
+  private List<IssueLinkType> issueLinkTypes;
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/IssueType.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/IssueType.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
@@ -27,7 +25,7 @@ public class IssueType implements Serializable {
   private static final long serialVersionUID = -4350803739177634227L;
 
   @JsonProperty("id")
-  private int id;
+  private String id;
 
   @JsonProperty("description")
   private String description;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Issues.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Issues.java
@@ -1,6 +1,7 @@
 package org.thoughtslive.jenkins.plugins.jira.api;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -8,28 +9,24 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@SuppressFBWarnings
 @Builder
 public class Issues implements Serializable {
 
   private static final long serialVersionUID = 3299430745665528801L;
 
   @JsonProperty("issueUpdates")
-  private Issue[] issueUpdates;
+  private List<Issue> issueUpdates;
 
   @JsonProperty("issues")
-  private Issue[] issues;
+  private List<Issue> issues;
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/LoginInfo.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/LoginInfo.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Notify.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Notify.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Priority.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Priority.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Project.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Project.java
@@ -2,6 +2,7 @@
 package org.thoughtslive.jenkins.plugins.jira.api;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -9,27 +10,23 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Builder
-@SuppressFBWarnings
 public class Project implements Serializable {
 
   private static final long serialVersionUID = -4217312651288636551L;
 
   @JsonProperty("id")
-  private int id;
+  private String id;
 
   @JsonProperty("key")
   private String key;
@@ -44,13 +41,13 @@ public class Project implements Serializable {
   private User lead;
 
   @JsonProperty("components")
-  private Component[] components;
+  private List<Component> components;
 
   @JsonProperty("versions")
-  private Version[] versions;
+  private List<Version> versions;
 
   @JsonProperty("issueTypes")
-  private IssueType[] issueTypes;
+  private List<IssueType> issueTypes;
 
   @JsonProperty("projectCategory")
   private ProjectCategory projectCategory;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/ProjectCategory.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/ProjectCategory.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Resolution.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Resolution.java
@@ -12,10 +12,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/SearchResult.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/SearchResult.java
@@ -1,6 +1,7 @@
 package org.thoughtslive.jenkins.plugins.jira.api;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.thoughtslive.jenkins.plugins.jira.api.input.BasicIssue;
@@ -9,20 +10,16 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@SuppressFBWarnings
 @Builder
 public class SearchResult implements Serializable {
 
@@ -41,5 +38,5 @@ public class SearchResult implements Serializable {
   private int total;
 
   @JsonProperty("issues")
-  private BasicIssue[] issues;
+  private List<BasicIssue> issues;
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Session.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Session.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Status.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Status.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/StatusCategory.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/StatusCategory.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
@@ -27,7 +25,7 @@ public class StatusCategory implements Serializable {
   private static final long serialVersionUID = 981603626054788439L;
 
   @JsonProperty("id")
-  private Integer id;
+  private String id;
 
   @JsonProperty("key")
   private String key;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/TimeTracking.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/TimeTracking.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Transition.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Transition.java
@@ -1,7 +1,6 @@
 package org.thoughtslive.jenkins.plugins.jira.api;
 
 import java.io.Serializable;
-import java.util.Map;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -13,10 +12,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
@@ -27,11 +24,9 @@ public class Transition implements Serializable {
   private static final long serialVersionUID = -5629975509520636980L;
 
   @JsonProperty("id")
-  private int id;
+  private String id;
 
   @JsonProperty("name")
   private String name;
 
-  @JsonProperty("fields")
-  private Map<String, Field> fields = null;
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Transitions.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Transitions.java
@@ -2,6 +2,7 @@
 package org.thoughtslive.jenkins.plugins.jira.api;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -9,25 +10,21 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@SuppressFBWarnings
 @Builder
 public class Transitions implements Serializable {
 
   private static final long serialVersionUID = -6854744607829718972L;
 
   @JsonProperty("transitions")
-  private Transition[] transitions;
+  private List<Transition> transitions;
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/User.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/User.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Version.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Version.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
@@ -57,6 +55,6 @@ public class Version implements Serializable {
   private String project;
 
   @JsonProperty("projectId")
-  private int projectId;
+  private String projectId;
 
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Votes.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Votes.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Watches.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Watches.java
@@ -2,6 +2,7 @@
 package org.thoughtslive.jenkins.plugins.jira.api;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -9,20 +10,16 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@SuppressFBWarnings
 @Builder
 public class Watches implements Serializable {
 
@@ -35,5 +32,5 @@ public class Watches implements Serializable {
   private Boolean isWatching;
 
   @JsonProperty("watchers")
-  private User[] watchers;
+  private List<User> watchers;
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Worklog.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Worklog.java
@@ -14,10 +14,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Worklogs.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/Worklogs.java
@@ -14,10 +14,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/BasicIssue.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/BasicIssue.java
@@ -13,10 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/BasicIssues.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/BasicIssues.java
@@ -1,6 +1,7 @@
 package org.thoughtslive.jenkins.plugins.jira.api.input;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -8,25 +9,21 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@SuppressFBWarnings
 @Builder
 public class BasicIssues implements Serializable {
 
   private static final long serialVersionUID = -8754445345363576641L;
 
   @JsonProperty("issues")
-  private BasicIssue[] issues;
+  private List<BasicIssue> issues;
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/FieldsInput.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/FieldsInput.java
@@ -1,6 +1,8 @@
 package org.thoughtslive.jenkins.plugins.jira.api.input;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.thoughtslive.jenkins.plugins.jira.api.Component;
@@ -13,24 +15,23 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Builder
-@SuppressFBWarnings
 public class FieldsInput implements Serializable {
 
   private static final long serialVersionUID = 466100668894754241L;
+
+  @JsonProperty("parent")
+  private BasicIssue parent;
 
   @JsonProperty("summary")
   private String summary;
@@ -48,7 +49,7 @@ public class FieldsInput implements Serializable {
 
   // The following are optional.
   @JsonProperty("labels")
-  private String[] labels;
+  private Set<String> labels;
 
   // Only name is required
   @JsonProperty("assignee")
@@ -56,10 +57,10 @@ public class FieldsInput implements Serializable {
 
   // Only Id is required
   @JsonProperty("components")
-  private Component[] components;
+  private List<Component> components;
 
   // Only Id is required
   @JsonProperty("fixVersions")
-  private Version[] fixVersions;
+  private List<Version> fixVersions;
 
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/IssueInput.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/IssueInput.java
@@ -12,10 +12,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/IssuesInput.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/IssuesInput.java
@@ -1,6 +1,7 @@
 package org.thoughtslive.jenkins.plugins.jira.api.input;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -8,26 +9,22 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Builder
-@SuppressFBWarnings
 public class IssuesInput implements Serializable {
 
   private static final long serialVersionUID = -5806366312318582080L;
 
   @JsonProperty("issueUpdates")
-  private IssueInput[] issueUpdates;
+  private List<IssueInput> issueUpdates;
 
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/TransitionInput.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/TransitionInput.java
@@ -2,9 +2,11 @@ package org.thoughtslive.jenkins.plugins.jira.api.input;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.thoughtslive.jenkins.plugins.jira.api.Comment;
+import org.thoughtslive.jenkins.plugins.jira.api.Field;
 import org.thoughtslive.jenkins.plugins.jira.api.Transition;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -15,25 +17,22 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@ToString
 @NoArgsConstructor
+@AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
 @Builder
 public class TransitionInput implements Serializable {
 
   private static final long serialVersionUID = 2345079536278547254L;
 
   @Data
-  @ToString
   @NoArgsConstructor
+  @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   @JsonIgnoreProperties(ignoreUnknown = true)
-  @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
   @Builder
   public static class Update implements Serializable {
 
@@ -44,11 +43,10 @@ public class TransitionInput implements Serializable {
   }
 
   @Data
-  @ToString
   @NoArgsConstructor
+  @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   @JsonIgnoreProperties(ignoreUnknown = true)
-  @AllArgsConstructor(onConstructor = @__({@DataBoundConstructor}))
   @Builder
   public static class CommentWrapper implements Serializable {
 
@@ -60,6 +58,9 @@ public class TransitionInput implements Serializable {
 
   @JsonProperty("update")
   private Update update;
+
+  @JsonProperty("fields")
+  private Map<String, Field> fields;
 
   @JsonProperty("transition")
   private Transition transition;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditCommentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditCommentStep.java
@@ -81,7 +81,8 @@ public class EditCommentStep extends BasicJiraStep {
       if (response == null) {
         logger.println("JIRA: Site - " + siteName + " - Updating comment: " + step.getComment()
             + " on issue: " + step.getIdOrKey());
-        response = jiraService.updateComment(step.getIdOrKey(), step.getCommentId(), step.getComment());
+        response =
+            jiraService.updateComment(step.getIdOrKey(), step.getCommentId(), step.getComment());
       }
 
       return logResponse(response);

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStep.java
@@ -113,8 +113,10 @@ public class NewIssueStep extends BasicJiraStep {
 
         }
 
-        if (issue.getFields().getIssuetype().getId() == 0) {
-          errorMessage = "fields->issuetype->id is zero or missing";
+        if (Util.fixEmpty(issue.getFields().getIssuetype().getId()) == null
+            && Util.fixEmpty(issue.getFields().getIssuetype().getName()) == null) {
+          errorMessage =
+              "fields->issuetype->id is missing and fields->issuetype->name is missing, one of these must present.";
         }
 
         if (issue.getFields().getProject() == null) {
@@ -122,8 +124,10 @@ public class NewIssueStep extends BasicJiraStep {
           return buildErrorResponse(new RuntimeException(errorMessage));
         }
 
-        if (issue.getFields().getProject().getId() == 0) {
-          errorMessage = "fields->project->id is zero or missing";
+        if (Util.fixEmpty(issue.getFields().getProject().getId()) == null
+            && Util.fixEmpty(issue.getFields().getProject().getKey()) == null) {
+          errorMessage =
+              "fields->project->id is missing and fields->project->key is missing, one of these must present.";
         }
 
         if (errorMessage != null) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStep.java
@@ -116,8 +116,10 @@ public class NewIssuesStep extends BasicJiraStep {
             return buildErrorResponse(new RuntimeException(errorMessage));
           }
 
-          if (issue.getFields().getIssuetype().getId() == 0) {
-            errorMessage = "fields->issuetype->id is zero or missing";
+          if (Util.fixEmpty(issue.getFields().getIssuetype().getId()) == null
+              && Util.fixEmpty(issue.getFields().getIssuetype().getName()) == null) {
+            errorMessage =
+                "fields->issuetype->id is missing and fields->issuetype->name is missing, one of these must present.";
           }
 
           if (issue.getFields().getProject() == null) {
@@ -125,8 +127,10 @@ public class NewIssuesStep extends BasicJiraStep {
             return buildErrorResponse(new RuntimeException(errorMessage));
           }
 
-          if (issue.getFields().getProject().getId() == 0) {
-            errorMessage = "fields->project->id is zero or missing";
+          if (Util.fixEmpty(issue.getFields().getProject().getId()) == null
+              && Util.fixEmpty(issue.getFields().getProject().getKey()) == null) {
+            errorMessage =
+                "fields->project->id is missing and fields->project->key is missing, one of these must present.";
           }
 
           if (errorMessage != null) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/TransitionIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/TransitionIssueStep.java
@@ -101,8 +101,8 @@ public class TransitionIssueStep extends BasicJiraStep {
           return buildErrorResponse(new RuntimeException(errorMessage));
         }
 
-        if (input.getTransition().getId() == 0) {
-          errorMessage = "notify->transition->id required or can't be zero.";
+        if (input.getTransition().getId() == null) {
+          errorMessage = "notify->transition->id missing";
         }
 
         if (errorMessage != null) {

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/EditCommentStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/EditCommentStepTest.java
@@ -140,8 +140,7 @@ public class EditCommentStepTest {
     stepExecution.run();
 
     // Assert Test
-    verify(jiraServiceMock, times(1)).updateComment("TEST-1", "1000",
-        "test comment");
+    verify(jiraServiceMock, times(1)).updateComment("TEST-1", "1000", "test comment");
     assertThat(step.isFailOnError()).isEqualTo(true);
   }
 }

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/EditIssueStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/EditIssueStepTest.java
@@ -65,8 +65,8 @@ public class EditIssueStepTest {
 
   final IssueInput issue = IssueInput.builder()
       .fields(FieldsInput.builder().description("TEST").summary("TEST")
-          .project(Project.builder().id(10000).build())
-          .issuetype(IssueType.builder().id(10000).build()).build())
+          .project(Project.builder().id("10000").build())
+          .issuetype(IssueType.builder().id("10000").build()).build())
       .build();
 
   @Before

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStepTest.java
@@ -62,8 +62,8 @@ public class NewIssueStepTest {
 
   final IssueInput issue = IssueInput.builder()
       .fields(FieldsInput.builder().description("TEST").summary("TEST")
-          .project(Project.builder().id(10000).build())
-          .issuetype(IssueType.builder().id(10000).build()).build())
+          .project(Project.builder().id("10000").build())
+          .issuetype(IssueType.builder().id("10000").build()).build())
       .build();
 
   @Before

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStepTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.junit.Before;
@@ -61,7 +63,7 @@ public class NewIssuesStepTest {
 
   NewIssuesStep.Execution stepExecution;
 
-  IssuesInput issues;
+  IssuesInput issuesInput;
 
   @Before
   public void setup() throws IOException, InterruptedException {
@@ -70,13 +72,13 @@ public class NewIssuesStepTest {
     when(envVarsMock.get("JIRA_SITE")).thenReturn("LOCAL");
     when(envVarsMock.get("BUILD_URL")).thenReturn("http://localhost:8080/jira-testing/job/01");
 
-    final IssueInput[] issue = new IssueInput[1];
-    issue[0] = IssueInput.builder()
+    final List<IssueInput> issues = new ArrayList<IssueInput>();
+    issues.add(IssueInput.builder()
         .fields(FieldsInput.builder().description("TEST").summary("TEST")
-            .project(Project.builder().id(10000).build())
-            .issuetype(IssueType.builder().id(10000).build()).build())
-        .build();
-    issues = IssuesInput.builder().issueUpdates(issue).build();
+            .project(Project.builder().id("10000").build())
+            .issuetype(IssueType.builder().id("10000").build()).build())
+        .build());
+    issuesInput = IssuesInput.builder().issueUpdates(issues).build();
     PowerMockito.mockStatic(Site.class);
     Mockito.when(Site.get(any())).thenReturn(siteMock);
     when(siteMock.getService()).thenReturn(jiraServiceMock);
@@ -96,14 +98,14 @@ public class NewIssuesStepTest {
 
   @Test
   public void testSuccessfulNewIssues() throws Exception {
-    final NewIssuesStep step = new NewIssuesStep(issues);
+    final NewIssuesStep step = new NewIssuesStep(issuesInput);
     stepExecution = new NewIssuesStep.Execution(step, contextMock);;
 
     // Execute Test.
     stepExecution.run();
 
     // Assert Test
-    verify(jiraServiceMock, times(1)).createIssues(issues);
+    verify(jiraServiceMock, times(1)).createIssues(issuesInput);
     assertThat(step.isFailOnError()).isEqualTo(true);
   }
 }

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/TransitionIssueStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/TransitionIssueStepTest.java
@@ -90,7 +90,7 @@ public class TransitionIssueStepTest {
   @Test
   public void testSuccessfulTransitionIssue() throws Exception {
     final TransitionInput input =
-        TransitionInput.builder().transition(Transition.builder().id(1000).build()).build();
+        TransitionInput.builder().transition(Transition.builder().id("1000").build()).build();
     final TransitionIssueStep step = new TransitionIssueStep("TEST-1", input);
     stepExecution = new TransitionIssueStep.Execution(step, contextMock);;
 


### PR DESCRIPTION
* NewIssue/NewIssues
** Allow issue type look up by name (fields->issuetype->name)
** Allow project look up by key (fields->project->key)
* @ToString is duplicate in all api objects (@Data should take care of
it already.)
* Array type can be just either List or Set. Changed across all objects.
* Fix fields variable is in the wrong position for Transitions