### PR TITLE
[JENKINS-48115] Get rid of isMetaStep()==true everywhere

### DIFF
--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddCommentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddCommentStep.java
@@ -51,11 +51,6 @@ public class AddCommentStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Add Comment";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddWatcherStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddWatcherStep.java
@@ -51,11 +51,6 @@ public class AddWatcherStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Add Watcher";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Void>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignableUserSearchStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignableUserSearchStep.java
@@ -62,11 +62,6 @@ public class AssignableUserSearchStep extends BasicJiraStep {
       return getPrefix()
           + "Searches assignable JIRA Users by username, name or email address for the given project/issueKey";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditCommentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditCommentStep.java
@@ -55,11 +55,6 @@ public class EditCommentStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Edit Issue Comment";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditComponentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditComponentStep.java
@@ -51,11 +51,6 @@ public class EditComponentStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Edit Component";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Void>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditIssueStep.java
@@ -51,11 +51,6 @@ public class EditIssueStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Edit Issue";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditVersionStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditVersionStep.java
@@ -50,11 +50,6 @@ public class EditVersionStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Edit Version";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Void>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/JqlSearchStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/JqlSearchStep.java
@@ -54,11 +54,6 @@ public class JqlSearchStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "JQL Search";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/LinkIssuesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/LinkIssuesStep.java
@@ -60,11 +60,6 @@ public class LinkIssuesStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Link Issues";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Void>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewComponentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewComponentStep.java
@@ -45,11 +45,6 @@ public class NewComponentStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Create New Component";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStep.java
@@ -48,11 +48,6 @@ public class NewIssueStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Create New Issue";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStep.java
@@ -49,11 +49,6 @@ public class NewIssuesStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Create New Issues";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewVersionStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewVersionStep.java
@@ -45,11 +45,6 @@ public class NewVersionStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Create New Version";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NotifyIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NotifyIssueStep.java
@@ -51,11 +51,6 @@ public class NotifyIssueStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Notify Issue";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Void>> {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/UserSearchStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/UserSearchStep.java
@@ -54,11 +54,6 @@ public class UserSearchStep extends BasicJiraStep {
     public String getDisplayName() {
       return getPrefix() + "Search Active JIRA Users by username, name or email address.";
     }
-
-    @Override
-    public boolean isMetaStep() {
-      return true;
-    }
   }
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {


### PR DESCRIPTION
[JENKINS-48115](https://issues.jenkins-ci.org/browse/JENKINS-48115)

`isMetaStep()` should only be returning true for actual metasteps like
https://github.com/jenkinsci/workflow-basic-steps-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java. Returning
true for steps like `NewComponentStep` in particular (because its
parameter is `Object`, so it ends up showing up as a metastep for
literally every possible object!) breaks a bunch of things -
Declarative's transformation logic, the ability to execute `CoreStep`s
like `archiveArtifacts`, and probably a bunch more things.

So, stop returning true from `isMetaStep()`. While we're bandaiding
around this in Declarative and `workflow-step-api` in
https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/221
and https://github.com/jenkinsci/workflow-step-api-plugin/pull/31,
there may well be other ways in which this is causing problems.

cc @reviewbybees @jglick @svanoort 