### PR TITLE
Add GetDevStatus step

### DIFF
--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraEndPoints.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraEndPoints.java
@@ -186,4 +186,10 @@ public interface JiraEndPoints {
   @Streaming
   @GET
   Call<ResponseBody> downloadFileWithDynamicUrl(@Url String fileUrl);
+
+  // Dev Status
+  @GET("rest/dev-status/1.0/issue/detail")
+  Call<Object> getDevStatus(@Query("issueId") String issueId,
+                            @Query("applicationType") String applicationType,
+                            @Query("dataType") String dataType);
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraService.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraService.java
@@ -480,4 +480,22 @@ public class JiraService {
       return buildErrorResponse(e);
     }
   }
+
+  // Development Status
+
+  /**
+   * Queries the issue for dev status by given id.
+   *
+   * @param issueId issue id.
+   * @return issue.
+   */
+  public ResponseData<Object> getDevStatus(final String issueId) {
+    try {
+      return parseResponse(jiraEndPoints.getDevStatus(issueId, "stash", "pullrequest").execute());
+    } catch (Exception e) {
+      return buildErrorResponse(e);
+    }
+  }
+
+
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetDevStatusStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetDevStatusStep.java
@@ -1,0 +1,98 @@
+package org.thoughtslive.jenkins.plugins.jira.steps;
+
+import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorResponse;
+
+import hudson.Extension;
+import hudson.Util;
+import java.io.IOException;
+import lombok.Getter;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.thoughtslive.jenkins.plugins.jira.api.ResponseData;
+import org.thoughtslive.jenkins.plugins.jira.util.JiraStepDescriptorImpl;
+import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
+
+/**
+ * Step to query a JIRA Issue.
+ *
+ * @author Fredrik Andersson
+ */
+public class GetDevStatusStep extends BasicJiraStep {
+
+  private static final long serialVersionUID = 3608031287666026126L;
+
+  @Getter
+  private final String id;
+
+  @DataBoundConstructor
+  public GetDevStatusStep(final String id) {
+    this.id = id;
+  }
+
+  @Override
+  public StepExecution start(StepContext context) throws Exception {
+    return new Execution(this, context);
+  }
+
+  @Extension
+  public static class DescriptorImpl extends JiraStepDescriptorImpl {
+
+    @Override
+    public String getFunctionName() {
+      return "jiraGetDevStatus";
+    }
+
+    @Override
+    public String getDisplayName() {
+      return getPrefix() + "Get Dev Status";
+    }
+
+  }
+
+  public static class Execution extends JiraStepExecution<ResponseData<Object>> {
+
+    private static final long serialVersionUID = 6898696015602575211L;
+
+    private final GetDevStatusStep step;
+
+    protected Execution(final GetDevStatusStep step, final StepContext context)
+        throws IOException, InterruptedException {
+      super(context);
+      this.step = step;
+    }
+
+    @Override
+    protected ResponseData<Object> run() throws Exception {
+
+      ResponseData<Object> response = verifyInput();
+
+      if (response == null) {
+        logger.println(
+            "JIRA: Site - " + siteName + " - Querying issue with id: " + step.getId());
+        response = jiraService.getDevStatus(step.getId());
+      }
+
+      return logResponse(response);
+    }
+
+    @Override
+    protected <T> ResponseData<T> verifyInput() throws Exception {
+      String errorMessage = null;
+      ResponseData<T> response = verifyCommon(step);
+
+      if (response == null) {
+        final String id = Util.fixEmpty(step.getId());
+
+        if (id == null) {
+          errorMessage = "id is empty or null.";
+        }
+
+        if (errorMessage != null) {
+          response = buildErrorResponse(new RuntimeException(errorMessage));
+        }
+      }
+      return response;
+    }
+  }
+}

--- a/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/GetDevStatusStep/config.jelly
+++ b/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/GetDevStatusStep/config.jelly
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly
+	xmlns:j="jelly:core"
+	xmlns:st="jelly:stapler"
+	xmlns:d="jelly:define"
+	xmlns:l="/lib/layout"
+	xmlns:t="/lib/hudson"
+	xmlns:f="/lib/form"
+	xmlns:i="jelly:fmt">
+  <f:entry field="id" title="Issue Id">
+  	<f:textbox/>
+  </f:entry>
+  <f:advanced>
+  	<f:entry field="site" title="Site Name">
+		<f:select/>
+  	</f:entry>
+  	<f:entry field="failOnError">
+  		<f:checkbox title="Fail On Error" default="true"/>
+  	</f:entry>
+  </f:advanced>
+  <f:block>
+     <p>See <a href="https://jenkinsci.github.io/jira-steps-plugin/steps/issue/jira_get_dev_status/" target="_blank">jiraGetDevStatus</a> for more information.</p>
+  </f:block>    
+</j:jelly>

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetDevStatusStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetDevStatusStepTest.java
@@ -1,0 +1,105 @@
+package org.thoughtslive.jenkins.plugins.jira.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import hudson.AbortException;
+import hudson.EnvVars;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.thoughtslive.jenkins.plugins.jira.Site;
+import org.thoughtslive.jenkins.plugins.jira.api.ResponseData;
+import org.thoughtslive.jenkins.plugins.jira.api.ResponseData.ResponseDataBuilder;
+import org.thoughtslive.jenkins.plugins.jira.service.JiraService;
+
+import java.io.IOException;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit test cases for GetDevStatusStep class.
+ *
+ * @author Naresh Rayapati
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GetDevStatusStep.class, Site.class})
+public class GetDevStatusStepTest {
+
+  @Mock
+  TaskListener taskListenerMock;
+  @Mock
+  Run<?, ?> runMock;
+  @Mock
+  EnvVars envVarsMock;
+  @Mock
+  PrintStream printStreamMock;
+  @Mock
+  JiraService jiraServiceMock;
+  @Mock
+  Site siteMock;
+  @Mock
+  StepContext contextMock;
+
+  private GetDevStatusStep.Execution stepExecution;
+
+  @Before
+  public void setup() throws IOException, InterruptedException {
+
+    // Prepare site.
+    when(envVarsMock.get("JIRA_SITE")).thenReturn("LOCAL");
+    when(envVarsMock.get("BUILD_URL")).thenReturn("http://localhost:8080/jira-testing/job/01");
+
+    PowerMockito.mockStatic(Site.class);
+    Mockito.when(Site.get(any())).thenReturn(siteMock);
+    when(siteMock.getService()).thenReturn(jiraServiceMock);
+
+    when(runMock.getCauses()).thenReturn(null);
+    when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
+    doNothing().when(printStreamMock).println();
+
+    final ResponseDataBuilder<Object> builder = ResponseData.builder();
+    when(jiraServiceMock.getDevStatus(anyString()))
+        .thenReturn(builder.successful(true).code(200).message("Success").build());
+    when(contextMock.get(Run.class)).thenReturn(runMock);
+    when(contextMock.get(TaskListener.class)).thenReturn(taskListenerMock);
+    when(contextMock.get(EnvVars.class)).thenReturn(envVarsMock);
+  }
+
+  @Test
+  public void testWithEmptyIdThrowsAbortException() throws Exception {
+    final GetDevStatusStep step = new GetDevStatusStep("");
+    stepExecution = new GetDevStatusStep.Execution(step, contextMock);
+    ;
+
+    // Execute and assert Test.
+    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
+      stepExecution.run();
+    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException")
+        .withNoCause();
+  }
+
+  @Test
+  public void testSuccessfulGetDevStatus() throws Exception {
+    final GetDevStatusStep step = new GetDevStatusStep("TEST-1");
+    stepExecution = new GetDevStatusStep.Execution(step, contextMock);
+    ;
+
+    // Execute Test.
+    stepExecution.run();
+
+    // Assert Test
+    verify(jiraServiceMock, times(1)).getDevStatus("TEST-1");
+    assertThat(step.isFailOnError()).isEqualTo(true);
+  }
+}


### PR DESCRIPTION
Jira, when connected to a development tool such as Bitbucket, gather
 info on development progress. This info can be accessed via a rather
 underdocumented interface.

This commit add a step to query the interface for development
 information.

Ex)
withEnv(['JIRA_SITE=<SITE>']) {
    def stats = jiraGetDevStatus("<issueId>")
    echo stats.toString()
}
