### PR TITLE
JENKINS-50764 Whitelist ResponseData getData signature in In-process script approval

### DIFF
--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/BasicJiraStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/BasicJiraStep.java
@@ -1,7 +1,11 @@
 package org.thoughtslive.jenkins.plugins.jira.steps;
 
+import hudson.Extension;
+import java.io.IOException;
 import java.io.Serializable;
 import lombok.Getter;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -25,4 +29,14 @@ public abstract class BasicJiraStep extends Step implements Serializable {
   @Getter
   @DataBoundSetter
   private boolean auditLog = true;
+
+  @Extension
+  public static class JiraWhitelist extends ProxyWhitelist {
+
+    public JiraWhitelist() throws IOException {
+      super(new StaticWhitelist(
+          "method org.thoughtslive.jenkins.plugins.jira.api.ResponseData getData"
+      ));
+    }
+  }
 }


### PR DESCRIPTION
# Description

* Whitelist ResponseData getData signature in In-process script approval.

See [JENKINS-50764](https://issues.jenkins-ci.org/browse/JENKINS-50764).