### PR TITLE
JENKINS-50764 Whitelist ResponseData method signatures in In-process script approval.

### DIFF
--- a/hugo/content/changelog.md
+++ b/hugo/content/changelog.md
@@ -5,9 +5,11 @@ date = "2017-11-12"
 lastmodifierdisplayname = "Naresh Rayapati"
 +++
 
-* #### **1.4.3** (Unreleased)
+* #### **1.4.4** (Unreleased)
 
-
+* #### **1.4.3**
+  * [JENKINS-50764](https://issues.jenkins-ci.org/browse/JENKINS-50764) Whitelist ResponseData method signatures in In-process script approval.
+      * With 1.4.2 only getData was added to the whitelist but here added rest.
 * #### **1.4.2**
   * [JENKINS-50764](https://issues.jenkins-ci.org/browse/JENKINS-50764) Whitelist ResponseData getData signature in In-process script approval.
 * #### **1.4.1**

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/ResponseData.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/ResponseData.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 @Data
 @ToString(of = {"successful", "code", "message", "error", "data"})
@@ -16,13 +17,18 @@ public class ResponseData<T> implements Serializable {
 
   private static final long serialVersionUID = 7846727738826103343L;
 
+  @Whitelisted
   private boolean successful;
 
+  @Whitelisted
   private int code;
 
+  @Whitelisted
   private String message;
 
+  @Whitelisted
   private String error;
 
+  @Whitelisted
   private T data;
 }


### PR DESCRIPTION
# Description

See [JENKINS-50764](https://issues.jenkins-ci.org/browse/JENKINS-50764).
* Prior it was just getData was added to the whitelist but with this pull request added rest of the methods on this class. 