### PR TITLE
[JENKINS-53044] Implement GetServerInfoStep

### DIFF
--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetServerInfoStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetServerInfoStep.java
@@ -1,0 +1,75 @@
+package org.thoughtslive.jenkins.plugins.jira.steps;
+
+import hudson.Extension;
+import java.io.IOException;
+import java.util.Map;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.thoughtslive.jenkins.plugins.jira.api.ResponseData;
+import org.thoughtslive.jenkins.plugins.jira.util.JiraStepDescriptorImpl;
+import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
+
+/**
+ * Step to retrieve JIRA ServerInfo.
+ *
+ * @author Stuart Rowe
+ */
+public class GetServerInfoStep extends BasicJiraStep {
+
+  private static final long serialVersionUID = -439860819128513604L;
+
+  @DataBoundConstructor
+  public GetServerInfoStep() {
+  }
+
+  @Override
+  public StepExecution start(StepContext context) throws Exception {
+    return new Execution(this, context);
+  }
+
+  @Extension
+  public static class DescriptorImpl extends JiraStepDescriptorImpl {
+
+    @Override
+    public String getFunctionName() {
+      return "jiraGetServerInfo";
+    }
+
+    @Override
+    public String getDisplayName() {
+      return getPrefix() + "Get Server Info";
+    }
+  }
+
+  public static class Execution extends JiraStepExecution<ResponseData<Map<String, Object>>> {
+
+    private static final long serialVersionUID = -3058199854899051131L;
+
+    private final GetServerInfoStep step;
+
+    protected Execution(final GetServerInfoStep step, final StepContext context)
+        throws IOException, InterruptedException {
+      super(context);
+      this.step = step;
+    }
+
+    @Override
+    protected ResponseData<Map<String, Object>> run() throws Exception {
+
+      ResponseData<Map<String, Object>> response =  verifyInput();
+
+      if (response == null) {
+        logger.println("JIRA: Site - " + siteName + " - Get Server Info");
+        response = jiraService.getServerInfo();
+      }
+
+      return logResponse(response);
+    }
+
+    @Override
+    protected <T> ResponseData<T> verifyInput() throws Exception {
+      return verifyCommon(step);
+    }
+  }
+}

--- a/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/GetServerInfoStep/config.jelly
+++ b/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/GetServerInfoStep/config.jelly
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly
+	xmlns:j="jelly:core"
+	xmlns:st="jelly:stapler"
+	xmlns:d="jelly:define"
+	xmlns:l="/lib/layout"
+	xmlns:t="/lib/hudson"
+	xmlns:f="/lib/form"
+	xmlns:i="jelly:fmt">
+  <f:advanced>
+  	<f:entry field="site" title="Site Name">
+		<f:select/>
+  	</f:entry>
+  	<f:entry field="failOnError">
+  		<f:checkbox title="Fail On Error" default="true"/>
+  	</f:entry>
+  </f:advanced>
+</j:jelly>

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetServerInfoStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetServerInfoStepTest.java
@@ -1,0 +1,92 @@
+package org.thoughtslive.jenkins.plugins.jira.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import hudson.EnvVars;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Map;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.thoughtslive.jenkins.plugins.jira.Site;
+import org.thoughtslive.jenkins.plugins.jira.api.ResponseData;
+import org.thoughtslive.jenkins.plugins.jira.api.ResponseData.ResponseDataBuilder;
+import org.thoughtslive.jenkins.plugins.jira.service.JiraService;
+
+/**
+ * Unit test cases for GetServerInfoStep class.
+ *
+ * @author Stuart Rowe
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GetServerInfoStep.class, Site.class})
+public class GetServerInfoStepTest {
+
+  @Mock
+  TaskListener taskListenerMock;
+  @Mock
+  Run<?, ?> runMock;
+  @Mock
+  EnvVars envVarsMock;
+  @Mock
+  PrintStream printStreamMock;
+  @Mock
+  JiraService jiraServiceMock;
+  @Mock
+  Site siteMock;
+  @Mock
+  StepContext contextMock;
+
+  private GetServerInfoStep.Execution stepExecution;
+
+  @Before
+  public void setup() throws IOException, InterruptedException {
+
+    // Prepare site.
+    when(envVarsMock.get("JIRA_SITE")).thenReturn("LOCAL");
+    when(envVarsMock.get("BUILD_URL")).thenReturn("http://localhost:8080/jira-testing/job/01");
+
+    PowerMockito.mockStatic(Site.class);
+    Mockito.when(Site.get(any())).thenReturn(siteMock);
+    when(siteMock.getService()).thenReturn(jiraServiceMock);
+
+    when(runMock.getCauses()).thenReturn(null);
+    when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
+    doNothing().when(printStreamMock).println();
+
+    final ResponseDataBuilder<Map<String,Object>> builder = ResponseData.builder();
+    when(jiraServiceMock.getServerInfo())
+        .thenReturn(builder.successful(true).code(200).message("Success").build());
+    when(contextMock.get(Run.class)).thenReturn(runMock);
+    when(contextMock.get(TaskListener.class)).thenReturn(taskListenerMock);
+    when(contextMock.get(EnvVars.class)).thenReturn(envVarsMock);
+  }
+
+  @Test
+  public void testSuccessfulGetServerInfo() throws Exception {
+    final GetServerInfoStep step = new GetServerInfoStep();
+    stepExecution = new GetServerInfoStep.Execution(step, contextMock);
+    ;
+
+    // Execute Test.
+    stepExecution.run();
+
+    // Assert Test
+    verify(jiraServiceMock, times(1)).getServerInfo();
+    assertThat(step.isFailOnError()).isEqualTo(true);
+  }
+}


### PR DESCRIPTION
Expose JiraServer#getServerInfo() as a Pipeline step.

# Description

See [JENKINS-53044](https://issues.jenkins-ci.org/browse/JENKINS-53044).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
