### PR TITLE
Add jiraWaitForIssueUpdate step

### DIFF
--- a/hugo/content/steps/webhook/_index.md
+++ b/hugo/content/steps/webhook/_index.md
@@ -1,0 +1,11 @@
++++
+title = "WebHook"
+description = ""
+weight = 9
+date = "2018-08-19"
+lastmodifierdisplayname = "Ludovic Cintrat"
++++
+
+### WebHook Steps
+
+{{% children depth="2" showhidden="true" %}}

--- a/hugo/content/steps/webhook/jira_wait_for_issue_update.md
+++ b/hugo/content/steps/webhook/jira_wait_for_issue_update.md
@@ -1,0 +1,44 @@
++++
+title = "WaitForIssueUpdate"
+description = "More about jiraWaitForIssueUpdate step."
+tags = ["steps", "webhook"]
+weight = 1
+date = "2018-08-19"
+lastmodifierdisplayname = "Ludovic Cintrat"
++++
+
+### jiraWaitForIssueUpdate
+
+This step waits for an update on a particular issue.\
+Jira instance shall be configured with a webhook to the Jenkins instance at `http://<jenkins>/jira-steps-webhook/notify`.
+Only Jira "issue updated" events are handled for now.\
+More information on [Jira webhooks](https://developer.atlassian.com/server/jira/platform/webhooks/).
+
+#### Input
+
+* **idOrKey** - Issue id or key.
+* **field** - Issue field.
+* **fieldValues** - Expected new field values.
+* **site** - Optional, default: `JIRA_SITE` environment variable.
+* **failOnError** - Optional. default: `true`.
+
+{{% notice note %}}
+For more information about input, please refer to the model objects in the [API](https://github.com/jenkinsci/jira-steps-plugin/tree/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/api) package.
+{{% /notice %}}
+
+#### Output
+
+* New field value.
+
+#### Examples
+
+* Wait for an update of the 'status' field, either 'In Progress', either 'Done'.
+
+    ```groovy
+    node {
+      stage('JIRA') {
+        def newValue = jiraWaitForIssueUpdate site: 'Local', field: 'status', fieldValues: ['In Progress', 'Done'], idOrKey: 'TEST-1'
+        echo newValue
+      }
+    }
+    ```

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,13 @@
       <groupId>oauth.signpost</groupId>
       <artifactId>signpost-core</artifactId>
       <version>${signpost.oauth.version}</version>
+      <exclusions>
+		<!-- Conflict with jenkins-test-harness -->
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.oauth-client</groupId>

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/WaitForIssueUpdateStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/WaitForIssueUpdateStep.java
@@ -1,0 +1,148 @@
+package org.thoughtslive.jenkins.plugins.jira.steps;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.support.actions.PauseAction;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.thoughtslive.jenkins.plugins.jira.util.JiraStepDescriptorImpl;
+import org.thoughtslive.jenkins.plugins.jira.webhook.JiraIssueChangeListener;
+import org.thoughtslive.jenkins.plugins.jira.webhook.JiraWebHook;
+
+import com.google.common.collect.ImmutableSet;
+
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+/**
+ * Step to wait for an issue field to be updated.
+ *
+ * @author Ludovic Cintrat
+ */
+public class WaitForIssueUpdateStep extends Step implements Serializable {
+
+  private static final long serialVersionUID = -6061636623882913257L;
+
+  private final String idOrKey;
+
+  private final String field;
+
+  private final String[] fieldValues;
+
+  @DataBoundConstructor
+  public WaitForIssueUpdateStep(final String idOrKey, final String field, final String[] fieldValues) {
+
+    this.idOrKey = idOrKey;
+    this.field = field;
+    this.fieldValues = Arrays.copyOf(fieldValues, fieldValues.length);
+  }
+
+  @Override
+  public StepExecution start(StepContext context) throws Exception {
+    return new Execution(this, context);
+  }
+
+  static class Execution extends StepExecution implements JiraIssueChangeListener {
+
+    private static final long serialVersionUID = -4298923001851046514L;
+
+    private static final Logger LOG = Logger.getLogger(Execution.class.getName());
+
+    private final WaitForIssueUpdateStep step;
+
+    public Execution(WaitForIssueUpdateStep step, StepContext context) {
+      super(context);
+      this.step = step;
+    }
+
+    @Override
+    public boolean start() throws Exception {
+      log(
+          String.format(
+              "Waiting for issue %s [%s in (%s)]",
+              step.idOrKey,
+              step.field,
+              String.join(", ", step.fieldValues)));
+
+      FlowNode node = getContext().get(FlowNode.class);
+      node.addAction(new PauseAction("Jira WebHook"));
+
+      JiraWebHook.get().registerWebhook(this);
+
+      return false;
+    }
+
+    @Override
+    public void onResume() {
+      super.onResume();
+      JiraWebHook.get().registerWebhook(this);
+    }
+
+    @Override
+    public void stop(Throwable cause) throws Exception {
+      PauseAction.endCurrentPause(getContext().get(FlowNode.class));
+      JiraWebHook.get().unregisterWebhook(this);
+      getContext().onFailure(cause);
+    }
+
+    private boolean match(String field, String fieldValue) {
+      return step.field.equals(field) && ArrayUtils.contains(step.fieldValues, fieldValue);
+    }
+
+    @Override
+    public boolean onIssueUpdated(String field, String fieldValue) {
+      try {
+        if (match(field, fieldValue)) {
+          PauseAction.endCurrentPause(getContext().get(FlowNode.class));
+          getContext().onSuccess(fieldValue);
+
+          log(String.format("Jira issue %s updated [%s = %s]", step.idOrKey, field, fieldValue));
+          return true;
+        } else {
+          return false;
+        }
+      } catch (IOException | InterruptedException e) {
+        LOG.warning("onIssueUpdated: " + e);
+        return true;
+      }
+    }
+
+    @Override
+    public String getIssueIdOrKey() {
+      return step.idOrKey;
+    }
+
+    private void log(String msg, Object... args) throws IOException, InterruptedException {
+      getContext().get(TaskListener.class).getLogger().printf(msg, args);
+      getContext().get(TaskListener.class).getLogger().println();
+    }
+  }
+
+  @Extension
+  public static class DescriptorImpl extends JiraStepDescriptorImpl {
+
+    @Override
+    public String getFunctionName() {
+      return "jiraWaitForIssueUpdate";
+    }
+
+    @Override
+    public String getDisplayName() {
+      return getPrefix() + "Wait for an issue update";
+    }
+
+    @Override
+    public Set<Class<?>> getRequiredContext() {
+      return ImmutableSet.of(FlowNode.class, Run.class, TaskListener.class);
+    }
+  }
+}

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/webhook/JiraIssueChangeListener.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/webhook/JiraIssueChangeListener.java
@@ -1,0 +1,21 @@
+package org.thoughtslive.jenkins.plugins.jira.webhook;
+
+public interface JiraIssueChangeListener {
+  /**
+   * Return the issue observed by this listener
+   * 
+   * @return Issue key or id
+   */
+  String getIssueIdOrKey();
+
+  /**
+   * Notify issue change
+   * 
+   * @param field
+   *          changed field
+   * @param fieldValue
+   *          new field value
+   * @return true if handled by this listener, false otherwise
+   */
+  boolean onIssueUpdated(String field, String fieldValue);
+}

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/webhook/JiraWebHook.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/webhook/JiraWebHook.java
@@ -1,0 +1,183 @@
+package org.thoughtslive.jenkins.plugins.jira.webhook;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+
+import hudson.Extension;
+import hudson.model.RootAction;
+import hudson.model.UnprotectedRootAction;
+import jenkins.model.Jenkins;
+
+@Extension
+public class JiraWebHook implements UnprotectedRootAction {
+
+  public static final String URL_PATH = "jira-steps-webhook";
+
+  private static final String EVENT_ISSUE_UPDATED = "jira:issue_updated";
+
+  private static final Logger LOG = Logger.getLogger(JiraWebHook.class.getName());
+
+  @VisibleForTesting
+  public final Map<String, List<JiraIssueChangeListener>> listeners = new HashMap<>();
+
+  @Override
+  public String getIconFileName() {
+    return null;
+  }
+
+  @Override
+  public String getDisplayName() {
+    return null;
+  }
+
+  @Override
+  public String getUrlName() {
+    return URL_PATH;
+  }
+
+  public void registerWebhook(JiraIssueChangeListener listener) {
+    LOG.fine("Registering hook for " + listener.getIssueIdOrKey());
+    synchronized (listeners) {
+      List<JiraIssueChangeListener> issueListeners = listeners.get(listener.getIssueIdOrKey());
+
+      if (issueListeners == null) {
+        issueListeners = new ArrayList<>();
+        listeners.put(listener.getIssueIdOrKey(), issueListeners);
+      }
+
+      issueListeners.add(listener);
+    }
+  }
+
+  public void unregisterWebhook(JiraIssueChangeListener listener) {
+    LOG.fine("Unregistering hook for " + listener.getIssueIdOrKey());
+    synchronized (listeners) {
+      List<JiraIssueChangeListener> issueListeners = listeners.get(listener.getIssueIdOrKey());
+
+      if (issueListeners == null) {
+        LOG.fine("Removing unregistered JiraIssueChangeListener");
+      } else {
+        issueListeners.remove(listener);
+        if (issueListeners.isEmpty()) {
+          listeners.remove(listener.getIssueIdOrKey());
+        }
+      }
+    }
+  }
+
+  private void notifyListeners(List<JiraIssueChangeListener> listeners, String field, String fieldValue) {
+    // use ListIterator in order to remove elements
+    for (ListIterator<JiraIssueChangeListener> it = listeners.listIterator(); it.hasNext();) {
+      JiraIssueChangeListener listener = it.next();
+      if (listener.onIssueUpdated(field, fieldValue)) {
+        it.remove();
+      }
+    }
+  }
+
+  private void notifyUpdatedFields(String issueKey, JsonNode items) {
+    synchronized (listeners) {
+      List<JiraIssueChangeListener> issueListeners = listeners.get(issueKey);
+
+      if (issueListeners == null) {
+        return;
+      }
+
+      for (Iterator<JsonNode> i = items.iterator(); i.hasNext();) {
+        JsonNode item = i.next();
+        JsonNode field = item.get("field");
+        JsonNode toString = item.get("toString");
+
+        if (field != null && toString != null) {
+          LOG.fine("Jira issue field changed: " + field.asText() + " --> " + toString.asText());
+
+          notifyListeners(issueListeners, field.asText(), toString.asText());
+        }
+      }
+
+      // if there is no listener waiting for this issue, remove entry
+      if (listeners.get(issueKey).isEmpty()) {
+        listeners.remove(issueKey);
+      }
+    }
+  }
+
+  private int onIssueUpdatedEvent(JsonNode notification) {
+    JsonNode issue = notification.get("issue");
+
+    if (issue == null) {
+      return StaplerResponse.SC_BAD_REQUEST;
+    }
+
+    JsonNode issueKey = issue.get("key");
+
+    if (issueKey == null) {
+      return StaplerResponse.SC_BAD_REQUEST;
+    }
+
+    LOG.info("Jira issue updated: " + issueKey);
+
+    JsonNode changelog = notification.get("changelog");
+
+    if (changelog == null) {
+      return StaplerResponse.SC_BAD_REQUEST;
+    }
+
+    JsonNode items = changelog.get("items");
+
+    if (items == null) {
+      return StaplerResponse.SC_BAD_REQUEST;
+    }
+
+    notifyUpdatedFields(issueKey.asText(), items);
+
+    return StaplerResponse.SC_NO_CONTENT;
+  }
+
+  @RequirePOST
+  public void doNotify(StaplerRequest request, StaplerResponse response) throws IOException {
+    int sc;
+
+    LOG.fine("Handling notify hook");
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    JsonNode notification = mapper.readTree(request.getReader());
+
+    LOG.finest(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(notification));
+
+    JsonNode webhookEvent = notification.get("webhookEvent");
+
+    if (webhookEvent == null) {
+      response.setStatus(StaplerResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    if (!EVENT_ISSUE_UPDATED.equals(webhookEvent.asText())) {
+      response.setStatus(StaplerResponse.SC_NOT_IMPLEMENTED);
+      return;
+    }
+
+    sc = onIssueUpdatedEvent(notification);
+
+    response.setStatus(sc);
+  }
+
+  public static JiraWebHook get() {
+    return Jenkins.getInstance().getExtensionList(RootAction.class).get(JiraWebHook.class);
+  }
+}

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/webhook/JiraWebHookCrumbExclusion.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/webhook/JiraWebHookCrumbExclusion.java
@@ -1,0 +1,45 @@
+package org.thoughtslive.jenkins.plugins.jira.webhook;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import hudson.Extension;
+import hudson.security.csrf.CrumbExclusion;
+
+@Extension
+public class JiraWebHookCrumbExclusion extends CrumbExclusion {
+
+  @VisibleForTesting
+  public final Map<String, List<JiraIssueChangeListener>> listeners = new HashMap<>();
+
+  @Override
+  public boolean process(HttpServletRequest req, HttpServletResponse resp, FilterChain chain)
+      throws IOException, ServletException {
+    String pathInfo = req.getPathInfo();
+
+    if (StringUtils.isEmpty(pathInfo)) {
+      return false;
+    }
+
+    if (!pathInfo.startsWith(getExclusionPath())) {
+      return false;
+    }
+    chain.doFilter(req, resp);
+    return true;
+  }
+
+  public String getExclusionPath() {
+    return "/" + JiraWebHook.URL_PATH + "/";
+  }
+}

--- a/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/WaitForIssueUpdateStep/config.jelly
+++ b/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/WaitForIssueUpdateStep/config.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly
+	xmlns:j="jelly:core"
+	xmlns:st="jelly:stapler"
+	xmlns:d="jelly:define"
+	xmlns:l="/lib/layout"
+	xmlns:t="/lib/hudson"
+	xmlns:f="/lib/form"
+	xmlns:i="jelly:fmt">
+  <f:entry field="idOrKey" title="Issue Id/Key">
+  	<f:textbox/>
+  </f:entry>
+  <f:entry field="field" title="Field">
+  	<f:textbox/>
+  </f:entry>
+  <f:entry field="fieldValue" title="Expected New Values">
+  	<f:textbox/>
+  </f:entry>
+  <f:advanced>
+  	<f:entry field="site" title="Site Name">
+		<f:select/>
+  	</f:entry>
+  	<f:entry field="failOnError">
+  		<f:checkbox title="Fail On Error" default="true"/>
+  	</f:entry>
+  </f:advanced>
+  <f:block>
+     <p>See <a href="https://jenkinsci.github.io/jira-steps-plugin/steps/webhook/jira_wait_for_issue_update/" target="_blank">jiraWaitForIssueChange</a> for more information.</p>
+  </f:block>  
+</j:jelly>

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/WaitForIssueUpdateStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/WaitForIssueUpdateStepTest.java
@@ -1,0 +1,227 @@
+package org.thoughtslive.jenkins.plugins.jira.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule.JSONWebResponse;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.kohsuke.stapler.StaplerResponse;
+import org.thoughtslive.jenkins.plugins.jira.webhook.JiraWebHook;
+import org.xml.sax.SAXException;
+
+import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
+
+public class WaitForIssueUpdateStepTest {
+
+  private static final String JOB_NAME1 = "testJob1";
+  private static final String JOB_NAME2 = "testJob2";
+
+  WaitForIssueUpdateStep.Execution stepExecution;
+
+  @Rule
+  public RestartableJenkinsRule story = new RestartableJenkinsRule();
+  @ClassRule
+  public static BuildWatcher bw = new BuildWatcher();
+
+  @Test
+  public void waitForStatusOk() throws InterruptedException, IOException, SAXException {
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        QueueTaskFuture<WorkflowRun> pipeline = submitPipeline(JOB_NAME1, "TEST-1", "status", "'In Progress', 'Done'");
+        WorkflowRun b = pipeline.waitForStart();
+
+        waitForStepToWait(1, b);
+        JSONWebResponse rsp = submitWebHook("TEST-1", "status", "Done");
+        assertThat(rsp.getStatusCode()).isEqualTo(StaplerResponse.SC_NO_CONTENT);
+        story.j.assertBuildStatusSuccess(pipeline);
+        assertThat(JiraWebHook.get().listeners.get("TEST-1")).isNull();
+      }
+    });
+  }
+
+  @Test
+  public void waitForStatusOk2Issues() throws InterruptedException, IOException, SAXException {
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        QueueTaskFuture<WorkflowRun> pipeline = submitPipeline(JOB_NAME1, "TEST-1", "status", "'In Progress', 'Done'");
+        pipeline.waitForStart();
+
+        QueueTaskFuture<WorkflowRun> pipeline2 = submitPipeline(JOB_NAME2, "TEST-2", "status", "'In Progress', 'Done'");
+        WorkflowRun b2 = pipeline2.waitForStart();
+        waitForStepToWait(2, b2);
+
+        assertThat(JiraWebHook.get().listeners.get("TEST-1")).hasSize(1);
+        assertThat(JiraWebHook.get().listeners.get("TEST-2")).hasSize(1);
+
+        JSONWebResponse rsp = submitWebHook("TEST-1", "status", "Done");
+        assertThat(rsp.getStatusCode()).isEqualTo(StaplerResponse.SC_NO_CONTENT);
+        story.j.assertBuildStatusSuccess(pipeline);
+
+        assertThat(JiraWebHook.get().listeners.get("TEST-1")).isNull();
+        assertThat(JiraWebHook.get().listeners.get("TEST-2")).hasSize(1);
+
+        rsp = submitWebHook("TEST-2", "status", "Done");
+        assertThat(rsp.getStatusCode()).isEqualTo(StaplerResponse.SC_NO_CONTENT);
+        story.j.assertBuildStatusSuccess(pipeline2);
+
+        assertThat(JiraWebHook.get().listeners.get("TEST-1")).isNull();
+        assertThat(JiraWebHook.get().listeners.get("TEST-2")).isNull();
+      }
+    });
+  }
+
+  @Test
+  public void waitForStatusOk2Fields() throws InterruptedException, IOException, SAXException {
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        QueueTaskFuture<WorkflowRun> pipeline = submitPipeline(JOB_NAME1, "TEST-1", "status", "'In Progress', 'Done'");
+        pipeline.waitForStart();
+
+        QueueTaskFuture<WorkflowRun> pipeline2 = submitPipeline(JOB_NAME2, "TEST-1", "severity", "'High'");
+        WorkflowRun b2 = pipeline2.waitForStart();
+        waitForStepToWait(1, b2);
+
+        assertThat(JiraWebHook.get().listeners.get("TEST-1")).hasSize(2);
+
+        JSONWebResponse rsp = submitWebHook("TEST-1", "status", "Done");
+        assertThat(rsp.getStatusCode()).isEqualTo(StaplerResponse.SC_NO_CONTENT);
+        story.j.assertBuildStatusSuccess(pipeline);
+
+        assertThat(JiraWebHook.get().listeners.get("TEST-1")).hasSize(1);
+
+        rsp = submitWebHook("TEST-1", "severity", "High");
+        assertThat(rsp.getStatusCode()).isEqualTo(StaplerResponse.SC_NO_CONTENT);
+        story.j.assertBuildStatusSuccess(pipeline2);
+
+        assertThat(JiraWebHook.get().listeners.get("TEST-1")).isNull();
+      }
+    });
+  }
+
+  @Test
+  public void waitForStatusOk2Values() throws InterruptedException, IOException, SAXException {
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        QueueTaskFuture<WorkflowRun> pipeline = submitPipeline(JOB_NAME1, "TEST-1", "status", "'In Progress'");
+        pipeline.waitForStart();
+
+        QueueTaskFuture<WorkflowRun> pipeline2 = submitPipeline(JOB_NAME2, "TEST-1", "status", "'Done'");
+        WorkflowRun b2 = pipeline2.waitForStart();
+        waitForStepToWait(1, b2);
+
+        assertThat(JiraWebHook.get().listeners.get("TEST-1")).hasSize(2);
+
+        JSONWebResponse rsp = submitWebHook("TEST-1", "status", "In Progress");
+        assertThat(rsp.getStatusCode()).isEqualTo(StaplerResponse.SC_NO_CONTENT);
+        story.j.assertBuildStatusSuccess(pipeline);
+
+        assertThat(JiraWebHook.get().listeners.get("TEST-1")).hasSize(1);
+
+        rsp = submitWebHook("TEST-1", "status", "Done");
+        assertThat(rsp.getStatusCode()).isEqualTo(StaplerResponse.SC_NO_CONTENT);
+        story.j.assertBuildStatusSuccess(pipeline2);
+
+        assertThat(JiraWebHook.get().listeners.get("TEST-1")).isNull();
+      }
+    });
+  }
+
+  @Test
+  public void waitForStatusRestart() throws InterruptedException, IOException, SAXException {
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        QueueTaskFuture<WorkflowRun> pipeline = submitPipeline(JOB_NAME1, "TEST-1", "status", "'In Progress', 'Done'");
+        WorkflowRun b = pipeline.waitForStart();
+
+        waitForStepToWait(1, b);
+      }
+    });
+
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        WorkflowJob p = story.j.jenkins.getItemByFullName(JOB_NAME1, WorkflowJob.class);
+        WorkflowRun b = p.getLastBuild();
+        JSONWebResponse rsp = submitWebHook("TEST-1", "status", "Done");
+        assertThat(rsp.getStatusCode()).isEqualTo(StaplerResponse.SC_NO_CONTENT);
+        story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b));
+        assertThat(JiraWebHook.get().listeners.get("TEST-1")).isNull();
+      }
+    });
+  }
+
+  @Test
+  public void waitForStatusCancelPipeline() {
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        QueueTaskFuture<WorkflowRun> pipeline = submitPipeline(JOB_NAME1, "TEST-1", "status", "'In Progress'");
+        WorkflowRun b = pipeline.waitForStart();
+        waitForStepToWait(1, b);
+        b.doStop();
+        story.j.assertBuildStatus(Result.ABORTED, pipeline);
+        assertThat(JiraWebHook.get().listeners.get("TEST-1")).isNull();
+      }
+    });
+  }
+
+  private JSONWebResponse submitWebHook(String issueKey, String field, String toString)
+      throws InterruptedException, IOException, SAXException {
+
+    return story.j.postJSON(
+        "jira-steps-webhook/notify",
+        "{\n"
+            + "\"webhookEvent\":\"jira:issue_updated\",\n"
+            + "\"issue\": "
+            + "{ \"key\":"
+            + "\""
+            + issueKey
+            + "\""
+            + "},"
+            + "\"changelog\":{"
+            + "\"items\":["
+            + "{ \"field\":"
+            + "\""
+            + field
+            + "\","
+            + "\"toString\":\""
+            + toString
+            + "\""
+            + "}]}"
+            + "}");
+  }
+
+  private void waitForStepToWait(int expectedListeners, WorkflowRun b) throws InterruptedException {
+    // Wait for the step to register to the webhook listener
+    while (JiraWebHook.get().listeners.size() != expectedListeners && b.isBuilding()) {
+      Thread.sleep(500);
+    }
+  }
+
+  private QueueTaskFuture<WorkflowRun> submitPipeline(String jobName, String issueKey, String field, String values)
+      throws IOException, InterruptedException, ExecutionException {
+    JiraWebHook.get().listeners.clear();
+    WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, jobName);
+    p.setDefinition(
+        new CpsFlowDefinition(
+            "jiraWaitForIssueUpdate field: '" + field + "', fieldValues: [" + values + "], idOrKey: '" + issueKey + "'",
+            true));
+    return p.scheduleBuild2(0);
+  }
+}

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/webhook/JiraWebHookCrumbExclusionTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/webhook/JiraWebHookCrumbExclusionTest.java
@@ -1,0 +1,65 @@
+package org.thoughtslive.jenkins.plugins.jira.webhook;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+public class JiraWebHookCrumbExclusionTest {
+
+  private JiraWebHookCrumbExclusion exclusion;
+  private HttpServletRequest req;
+  private HttpServletResponse resp;
+  private FilterChain chain;
+
+  @Before
+  public void before() {
+    exclusion = new JiraWebHookCrumbExclusion();
+    req = mock(HttpServletRequest.class);
+    resp = mock(HttpServletResponse.class);
+    chain = mock(FilterChain.class);
+  }
+
+  @Test
+  public void testFullPath() throws Exception {
+    when(req.getPathInfo()).thenReturn("/jira-steps-webhook/");
+    assertThat(exclusion.process(req, resp, chain)).isTrue();
+    verify(chain, times(1)).doFilter(req, resp);
+  }
+
+  @Test
+  public void testFullPathWithoutSlash() throws Exception {
+    when(req.getPathInfo()).thenReturn("/jira-steps-webhook");
+    assertThat(exclusion.process(req, resp, chain)).isFalse();
+    verify(chain, never()).doFilter(req, resp);
+  }
+
+  @Test
+  public void testInvalidPath() throws Exception {
+    when(req.getPathInfo()).thenReturn("/some-other-url/");
+    assertThat(exclusion.process(req, resp, chain)).isFalse();
+    verify(chain, never()).doFilter(req, resp);
+  }
+
+  @Test
+  public void testNullPath() throws Exception {
+    when(req.getPathInfo()).thenReturn(null);
+    assertThat(exclusion.process(req, resp, chain)).isFalse();
+    verify(chain, never()).doFilter(req, resp);
+  }
+
+  @Test
+  public void testEmptyPath() throws Exception {
+    when(req.getPathInfo()).thenReturn("");
+    assertThat(exclusion.process(req, resp, chain)).isFalse();
+    verify(chain, never()).doFilter(req, resp);
+  }
+}

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/webhook/JiraWebHookTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/webhook/JiraWebHookTest.java
@@ -1,0 +1,108 @@
+package org.thoughtslive.jenkins.plugins.jira.webhook;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+public class JiraWebHookTest {
+
+  private JiraWebHook webhook;
+  private StaplerRequest req;
+  private StaplerResponse resp;
+
+  @Before
+  public void setup() {
+    webhook = new JiraWebHook();
+    req = mock(StaplerRequest.class);
+    resp = mock(StaplerResponse.class);
+  }
+
+  @Test
+  public void noWebHookEvent() throws Exception {
+
+    StringReader sr = new StringReader("{}");
+    BufferedReader br = new BufferedReader(sr);
+
+    when(req.getReader()).thenReturn(br);
+    webhook.doNotify(req, resp);
+    verify(resp, times(1)).setStatus(StaplerResponse.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void notImplementedEvent() throws Exception {
+
+    StringReader sr = new StringReader("{ \"webhookEvent\": \"jira:issue_created\"}");
+    BufferedReader br = new BufferedReader(sr);
+
+    when(req.getReader()).thenReturn(br);
+    webhook.doNotify(req, resp);
+    verify(resp, times(1)).setStatus(StaplerResponse.SC_NOT_IMPLEMENTED);
+  }
+
+  @Test
+  public void noIssue() throws Exception {
+
+    StringReader sr = new StringReader("{ \"webhookEvent\": \"jira:issue_updated\"}");
+    BufferedReader br = new BufferedReader(sr);
+
+    when(req.getReader()).thenReturn(br);
+    webhook.doNotify(req, resp);
+    verify(resp, times(1)).setStatus(StaplerResponse.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void noIssueKey() throws Exception {
+
+    StringReader sr = new StringReader("{ \"webhookEvent\": \"jira:issue_updated\", \"issue\": {}}");
+    BufferedReader br = new BufferedReader(sr);
+
+    when(req.getReader()).thenReturn(br);
+    webhook.doNotify(req, resp);
+    verify(resp, times(1)).setStatus(StaplerResponse.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void noChangeLog() throws Exception {
+
+    StringReader sr = new StringReader("{ \"webhookEvent\": \"jira:issue_updated\", \"issue\": {\"key\":\"TST-1\"}}");
+    BufferedReader br = new BufferedReader(sr);
+
+    when(req.getReader()).thenReturn(br);
+    webhook.doNotify(req, resp);
+    verify(resp, times(1)).setStatus(StaplerResponse.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void noChangeLogItems() throws Exception {
+
+    StringReader sr = new StringReader(
+        "{ \"webhookEvent\": \"jira:issue_updated\", \"issue\": {\"key\":\"TST-1\"}, \"changelog\":{}}");
+    BufferedReader br = new BufferedReader(sr);
+
+    when(req.getReader()).thenReturn(br);
+    webhook.doNotify(req, resp);
+    verify(resp, times(1)).setStatus(StaplerResponse.SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void changeLogItems() throws Exception {
+
+    StringReader sr = new StringReader(
+        "{ \"webhookEvent\": \"jira:issue_updated\", \"issue\": {\"key\":\"TST-1\"}, \"changelog\":{\"items\":{}}}");
+    BufferedReader br = new BufferedReader(sr);
+
+    when(req.getReader()).thenReturn(br);
+    webhook.doNotify(req, resp);
+    verify(resp, times(1)).setStatus(StaplerResponse.SC_NO_CONTENT);
+  }
+
+}


### PR DESCRIPTION
# Description

Add a new step allowing to pause a pipeline until a Jira issue is updated.

[JENKINS-53557](https://issues.jenkins-ci.org/browse/JENKINS-53557)

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
