### PR TITLE
JENKINS-54743 : Contribute JIRA_URL environment variable

### DIFF
--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/util/JiraStepExecution.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/util/JiraStepExecution.java
@@ -15,8 +15,11 @@ import hudson.model.TaskListener;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
+
+import org.jenkinsci.plugins.workflow.cps.EnvActionImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.support.actions.EnvironmentAction;
 import org.thoughtslive.jenkins.plugins.jira.Site;
 import org.thoughtslive.jenkins.plugins.jira.api.ResponseData;
 import org.thoughtslive.jenkins.plugins.jira.service.JiraService;
@@ -107,6 +110,16 @@ public abstract class JiraStepExecution<T> extends SynchronousNonBlockingStepExe
       return buildErrorResponse(new RuntimeException(errorMessage));
     }
 
+    if (site.getUrl() != null) {
+      try {
+        EnvActionImpl environmentAction = EnvActionImpl.forRun(run);
+        if (environmentAction != null) {
+          environmentAction.setProperty("JIRA_URL", site.getUrl().toString());
+        }
+      } catch (Exception ex) {
+        log(logger, "Exception while setting JIRA_URL environment variable: " + ex);
+      }
+    }
     buildUserId = prepareBuildUserId(run.getCauses());
     buildUrl = envVars.get("BUILD_URL");
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetServerInfoStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetServerInfoStepTest.java
@@ -12,8 +12,12 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.net.URL;
 import java.util.Map;
+
+import org.jenkinsci.plugins.workflow.cps.EnvActionImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.support.actions.EnvironmentAction;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +54,8 @@ public class GetServerInfoStepTest {
   Site siteMock;
   @Mock
   StepContext contextMock;
+  @Mock
+  EnvActionImpl envActionMock;
 
   private GetServerInfoStep.Execution stepExecution;
 
@@ -62,9 +68,11 @@ public class GetServerInfoStepTest {
 
     PowerMockito.mockStatic(Site.class);
     Mockito.when(Site.get(any())).thenReturn(siteMock);
+    when(siteMock.getUrl()).thenReturn(new URL("http://jira/instance"));
     when(siteMock.getService()).thenReturn(jiraServiceMock);
 
     when(runMock.getCauses()).thenReturn(null);
+    when(runMock.getAction(EnvActionImpl.class)).thenReturn(envActionMock);
     when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
     doNothing().when(printStreamMock).println();
 
@@ -85,6 +93,8 @@ public class GetServerInfoStepTest {
     stepExecution.run();
 
     // Assert Test
+    verify(runMock).getAction(EnvActionImpl.class);
+    verify(envActionMock).setProperty("JIRA_URL", "http://jira/instance");
     verify(jiraServiceMock, times(1)).getServerInfo();
     assertThat(step.isFailOnError()).isEqualTo(true);
   }


### PR DESCRIPTION
# Description
The idea is to use this environment variable to, for example, build links to issues.
We can get this information by calling _getServerInfo()_ but we have it from configuration, so if a remote call can be avoid ...

See [JENKINS-54743](https://issues.jenkins-ci.org/browse/JENKINS-54743).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
