### PR TITLE
Allow 'null' as username to assign the issue to 'Unassigned'

### DIFF
--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignIssueStep.java
@@ -87,14 +87,9 @@ public class AssignIssueStep extends BasicJiraStep {
 
       if (response == null) {
         final String idOrKey = Util.fixEmpty(step.getIdOrKey());
-        final String userName = Util.fixEmpty(step.getUserName());
 
         if (idOrKey == null) {
           errorMessage = "idOrKey is empty or null.";
-        }
-
-        if (userName == null) {
-          errorMessage = "userName is empty or null.";
         }
 
         if (errorMessage != null) {

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignIssueStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignIssueStepTest.java
@@ -94,15 +94,16 @@ public class AssignIssueStepTest {
 
   @Test
   public void testWithEmptyCommentThrowsAbortException() throws Exception {
-    final AssignIssueStep step = new AssignIssueStep("TEST-1", "");
+    final AssignIssueStep step = new AssignIssueStep("TEST-1", null);
     stepExecution = new AssignIssueStep.Execution(step, contextMock);
     ;
 
-    // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("userName is empty or null.").withStackTraceContaining("AbortException")
-        .withNoCause();
+    // Execute Test.
+    stepExecution.run();
+
+    // Assert Test
+    verify(jiraServiceMock, times(1)).assignIssue("TEST-1", null);
+    assertThat(step.isFailOnError()).isEqualTo(true);
   }
 
   @Test


### PR DESCRIPTION
Like in the API Documentation described: 
"Null" as username will assign the issue to the "Uanssigend" User.
See https://docs.atlassian.com/software/jira/docs/api/REST/7.12.0/?_ga=2.102846852.529308166.1548751507-144319608.1546936879#api/2/issue-assign

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
