### PR TITLE
Jenkins 59280: Fix jiraJqlSearch Error Message: null value after upgrade

### DIFF
--- a/hugo/content/steps/search/jira_jql_search.md
+++ b/hugo/content/steps/search/jira_jql_search.md
@@ -14,6 +14,8 @@ This step searches issues from the provided JIRA site by Jql.
 #### Input
 
 * **jql** - jql as a string.
+* **fields** - Optional. the list of fields to return for each issue. default: null (in this case the parameter is 
+not sent and all navigable fields are returned)
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
 

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraService.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraService.java
@@ -252,9 +252,16 @@ public class JiraService {
   public ResponseData<Object> searchIssues(final String jql, final int startAt,
       final int maxResults, final String fields) {
     try {
-      return parseResponse(jiraEndPoints.searchIssues(
-          ImmutableMap.builder().put("jql", jql).put("startAt", startAt)
-              .put("maxResults", maxResults).put("fields", fields).build()).execute());
+      ImmutableMap.Builder<Object, Object> paramsMap = ImmutableMap.builder()
+              .put("jql", jql)
+              .put("startAt", startAt)
+              .put("maxResults", maxResults);
+
+      if (fields != null) {
+        paramsMap.put("fields", fields);
+      }
+
+      return parseResponse(jiraEndPoints.searchIssues(paramsMap.build()).execute());
     } catch (Exception e) {
       return buildErrorResponse(e);
     }


### PR DESCRIPTION
# Description

See [JENKINS-59280](https://issues.jenkins-ci.org/browse/JENKINS-59280).

I see two approaches to this problem, which brings back the backward compatibilty with 1.4.5 version. One is mentioned in the attached ticket and done in this PR. 

The other approach would be to set _fields_ default value to `*navigable`, which [Jira REST API](https://docs.atlassian.com/software/jira/docs/api/REST/8.4.2/#api/2/search-search) mentions as the default value. I find this solution more elegant, but I think it would be relying to much on the JIRA API implementation and if this default value changes, then it would create an inconsistency. **Having said that, if you decide that this solution is better I would gladly change the code to this approach.**

# Test cases for this fix

There were no tests for JiraService previously.

# Test plan

1. Check if jiraJqlSearch step works fine without the fields parameter.
2. Documentation entry is correct

# Submitter checklist
- [x] Link to JIRA ticket in the description, if appropriate.
- [x] Change is code-complete and matches the issue description.
- [x] Appropriate unit or acceptance tests or explanation as to why this change has no tests.
- [x] Reviewer's manual test instructions provided in the PR description. See the Reviewer's first task below.

# Reviewer checklist
- [x] Run the changes and verified the change matches the issue description.
- [x] Reviewed the code.
- [x] Verified that the appropriate tests have been written or valid explanation given.
- [x] If applicable, tested by installing this plugin on the Jenkins instance.
