### PR TITLE
[docu] Update wrong naming of remoteIssueLink methods

### DIFF
--- a/hugo/content/steps/issuelink/jira_delete_remote_issuelink.md
+++ b/hugo/content/steps/issuelink/jira_delete_remote_issuelink.md
@@ -1,13 +1,13 @@
 +++
-title = "DeleteRemoteIssueLink"
-description = "More about jiraDeleteRemoteIssueLink step."
+title = "DeleteIssueRemoteLink"
+description = "More about jiraDeleteIssueRemoteLink step."
 tags = ["steps", "issue", "issuelink"]
 weight = 8
 date = "2017-11-12"
 lastmodifierdisplayname = "Naresh Rayapati"
 +++
 
-### jiraDeleteRemoteIssueLink
+### jiraDeleteIssueRemoteLink
 
 This step deletes a particular remote link of an issue.
 
@@ -40,7 +40,7 @@ It supports all the fields that any jira instance supports including custom fiel
     ```groovy
     node {
       stage('JIRA') {
-        def issueLink = jiraDeleteRemoteIssueLink idOrKey: 'TEST-27', linkId: '10000'
+        def issueLink = jiraDeleteIssueRemoteLink idOrKey: 'TEST-27', linkId: '10000'
         echo issueLink.data.toString()
       }
     }
@@ -51,7 +51,7 @@ It supports all the fields that any jira instance supports including custom fiel
     node {
       stage('JIRA') {
         withEnv(['JIRA_SITE=LOCAL']) {
-          def issueLink = jiraDeleteRemoteIssueLink idOrKey: 'TEST-27', linkId: '10000'
+          def issueLink = jiraDeleteIssueRemoteLink idOrKey: 'TEST-27', linkId: '10000'
           echo issueLink.data.toString()
         }
       }
@@ -60,6 +60,6 @@ It supports all the fields that any jira instance supports including custom fiel
 * Without environment variables.
 
     ```groovy
-    def issueLink = jiraDeleteRemoteIssueLink idOrKey: 'TEST-27', linkId: '10000', site: 'LOCAL', failOnError: false
+    def issueLink = jiraDeleteIssueRemoteLink idOrKey: 'TEST-27', linkId: '10000', site: 'LOCAL', failOnError: false
     echo issueLink.data.toString()
     ```

--- a/hugo/content/steps/issuelink/jira_delete_remote_issuelinks.md
+++ b/hugo/content/steps/issuelink/jira_delete_remote_issuelinks.md
@@ -1,13 +1,13 @@
 +++
-title = "DeleteRemoteIssueLinks"
-description = "More about jiraDeleteRemoteIssueLinks step."
+title = "DeleteIssueRemoteLinks"
+description = "More about jiraDeleteIssueRemoteLinks step."
 tags = ["steps", "issue", "issuelink"]
 weight = 9
 date = "2017-11-12"
 lastmodifierdisplayname = "Naresh Rayapati"
 +++
 
-### jiraDeleteRemoteIssueLinks
+### jiraDeleteIssueRemoteLinks
 
 This step deletes all remote links of an issue.
 
@@ -40,7 +40,7 @@ It supports all the fields that any jira instance supports including custom fiel
     ```groovy
     node {
       stage('JIRA') {
-        def issueLink = jiraDeleteRemoteIssueLinks idOrKey: 'TEST-27', globalId: '10000'
+        def issueLink = jiraDeleteIssueRemoteLinks idOrKey: 'TEST-27', globalId: '10000'
         echo issueLink.data.toString()
       }
     }
@@ -51,7 +51,7 @@ It supports all the fields that any jira instance supports including custom fiel
     node {
       stage('JIRA') {
         withEnv(['JIRA_SITE=LOCAL']) {
-          def issueLink = jiraDeleteRemoteIssueLinks idOrKey: 'TEST-27', globalId: '10000'
+          def issueLink = jiraDeleteIssueRemoteLinks idOrKey: 'TEST-27', globalId: '10000'
           echo issueLink.data.toString()
         }
       }
@@ -60,6 +60,6 @@ It supports all the fields that any jira instance supports including custom fiel
 * Without environment variables.
 
     ```groovy
-    def issueLink = jiraDeleteRemoteIssueLinks idOrKey: 'TEST-27', globalId: '10000', site: 'LOCAL', failOnError: false
+    def issueLink = jiraDeleteIssueRemoteLinks idOrKey: 'TEST-27', globalId: '10000', site: 'LOCAL', failOnError: false
     echo issueLink.data.toString()
     ```

--- a/hugo/content/steps/issuelink/jira_get_remote_issuelink.md
+++ b/hugo/content/steps/issuelink/jira_get_remote_issuelink.md
@@ -1,13 +1,13 @@
 +++
-title = "GetRemoteIssueLink"
-description = "More about jiraGetRemoteIssueLink step."
+title = "GetIssueRemoteLink"
+description = "More about jiraGetIssueRemoteLink step."
 tags = ["steps", "issue", "issuelink"]
 weight = 3
 date = "2017-11-12"
 lastmodifierdisplayname = "Naresh Rayapati"
 +++
 
-### jiraGetRemoteIssueLink
+### jiraGetIssueRemoteLink
 
 This step queries a particular remote link of an issue.
 
@@ -36,7 +36,7 @@ This step queries a particular remote link of an issue.
     ```groovy
     node {
       stage('JIRA') {
-        def issueLink = jiraGetRemoteIssueLink idOrKey: 'TEST-27', linkId: '10000'
+        def issueLink = jiraGetIssueRemoteLink idOrKey: 'TEST-27', linkId: '10000'
         echo issueLink.data.toString()
       }
     }
@@ -47,7 +47,7 @@ This step queries a particular remote link of an issue.
     node {
       stage('JIRA') {
         withEnv(['JIRA_SITE=LOCAL']) {
-          def issueLink = jiraGetRemoteIssueLink idOrKey: 'TEST-27', linkId: '10000'
+          def issueLink = jiraGetIssueRemoteLink idOrKey: 'TEST-27', linkId: '10000'
           echo issueLink.data.toString()
         }
       }
@@ -56,6 +56,6 @@ This step queries a particular remote link of an issue.
 * Without environment variables.
 
     ```groovy
-    def issueLink = jiraGetRemoteIssueLink idOrKey: 'TEST-27', linkId: '10000', site: 'LOCAL', failOnError: false
+    def issueLink = jiraGetIssueRemoteLink idOrKey: 'TEST-27', linkId: '10000', site: 'LOCAL', failOnError: false
     echo issueLink.data.toString()
     ```

--- a/hugo/content/steps/issuelink/jira_get_remote_issuelinks.md
+++ b/hugo/content/steps/issuelink/jira_get_remote_issuelinks.md
@@ -1,13 +1,13 @@
 +++
-title = "GetRemoteIssueLinks"
-description = "More about jiraGetRemoteIssueLinks step."
+title = "GetIssueRemoteLinks"
+description = "More about jiraGetIssueRemoteLinks step."
 tags = ["steps", "issue", "issuelink"]
 weight = 4
 date = "2017-11-12"
 lastmodifierdisplayname = "Naresh Rayapati"
 +++
 
-### jiraGetRemoteIssueLinks
+### jiraGetIssueRemoteLinks
 
 This step queries all the remote links of a particular issue.
 
@@ -36,7 +36,7 @@ This step queries all the remote links of a particular issue.
     ```groovy
     node {
       stage('JIRA') {
-        def issueLink = jiraGetRemoteIssueLinks idOrKey: 'TEST-27', globalId: '10000'
+        def issueLink = jiraGetIssueRemoteLinks idOrKey: 'TEST-27', globalId: '10000'
         echo issueLink.data.toString()
       }
     }
@@ -47,7 +47,7 @@ This step queries all the remote links of a particular issue.
     node {
       stage('JIRA') {
         withEnv(['JIRA_SITE=LOCAL']) {
-          def issueLink = jiraGetRemoteIssueLinks idOrKey: 'TEST-27', globalId: '10000'
+          def issueLink = jiraGetIssueRemoteLinks idOrKey: 'TEST-27', globalId: '10000'
           echo issueLink.data.toString()
         }
       }
@@ -56,6 +56,6 @@ This step queries all the remote links of a particular issue.
 * Without environment variables.
 
     ```groovy
-    def issueLink = jiraGetRemoteIssueLinks idOrKey: 'TEST-27', globalId: '10000', site: 'LOCAL', failOnError: false
+    def issueLink = jiraGetIssueRemoteLinks idOrKey: 'TEST-27', globalId: '10000', site: 'LOCAL', failOnError: false
     echo issueLink.data.toString()
     ```

--- a/hugo/content/steps/issuelink/jira_new_remote_issuelink.md
+++ b/hugo/content/steps/issuelink/jira_new_remote_issuelink.md
@@ -1,13 +1,13 @@
 +++
-title = "NewRemoteIssueLink"
-description = "More about jiraNewRemoteIssueLink step."
+title = "NewIssueRemoteLink"
+description = "More about jiraNewIssueRemoteLink step."
 tags = ["steps", "issue", "issuelink"]
 weight = 5
 date = "2017-11-12"
 lastmodifierdisplayname = "Naresh Rayapati"
 +++
 
-### jiraNewRemoteIssueLink
+### jiraNewIssueRemoteLink
 
 This step creates a new remote link to a particular issue.
 
@@ -47,7 +47,7 @@ It supports all the fields that any jira instance supports including custom fiel
                            object: [url: "http://www.mycompany.com/support?id=1",
                                     title: "MYTEST-111"]]
 
-        def issueLink = jiraNewRemoteIssueLink idOrKey: 'TEST-27', remoteLink: remoteLink
+        def issueLink = jiraNewIssueRemoteLink idOrKey: 'TEST-27', remoteLink: remoteLink
         echo issueLink.data.toString()
       }
     }
@@ -65,7 +65,7 @@ It supports all the fields that any jira instance supports including custom fiel
                              object: [url: "http://www.mycompany.com/support?id=1",
                                       title: "MYTEST-111"]]
 
-          def issueLink = jiraNewRemoteIssueLink idOrKey: 'TEST-27', remoteLink: remoteLink
+          def issueLink = jiraNewIssueRemoteLink idOrKey: 'TEST-27', remoteLink: remoteLink
           echo issueLink.data.toString()
         }
       }
@@ -81,6 +81,6 @@ It supports all the fields that any jira instance supports including custom fiel
                        object: [url: "http://www.mycompany.com/support?id=1",
                                 title: "MYTEST-111"]]
 
-    def issueLink = jiraNewRemoteIssueLink idOrKey: 'TEST-27', remoteLink: remoteLink, site: 'LOCAL', failOnError: false
+    def issueLink = jiraNewIssueRemoteLink idOrKey: 'TEST-27', remoteLink: remoteLink, site: 'LOCAL', failOnError: false
     echo issueLink.data.toString()
     ```

--- a/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinkStep/config.jelly
+++ b/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinkStep/config.jelly
@@ -21,7 +21,7 @@
   <f:block>
     <p>See <a
       href="https://jenkinsci.github.io/jira-steps-plugin/steps/issuelink/jira_delete_remote_issuelink/"
-      target="_blank">jiraDeleteRemoteIssueLink
+      target="_blank">jiraDeleteIssueRemoteLink
     </a> for more information.
     </p>
   </f:block>

--- a/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinksStep/config.jelly
+++ b/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinksStep/config.jelly
@@ -21,7 +21,7 @@
   <f:block>
     <p>See <a
       href="https://jenkinsci.github.io/jira-steps-plugin/steps/issuelink/jira_delete_remote_issuelinks/"
-      target="_blank">jiraDeleteRemoteIssueLinks
+      target="_blank">jiraDeleteIssueRemoteLinks
     </a> for more information.
     </p>
   </f:block>

--- a/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinkStep/config.jelly
+++ b/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinkStep/config.jelly
@@ -21,7 +21,7 @@
   <f:block>
     <p>See <a
       href="https://jenkinsci.github.io/jira-steps-plugin/steps/issuelink/jira_get_remote_issuelink/"
-      target="_blank">jiraGetRemoteIssueLink
+      target="_blank">jiraGetIssueRemoteLink
     </a> for more information.
     </p>
   </f:block>

--- a/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinksStep/config.jelly
+++ b/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinksStep/config.jelly
@@ -21,7 +21,7 @@
   <f:block>
     <p>See <a
       href="https://jenkinsci.github.io/jira-steps-plugin/steps/issuelink/jira_get_remote_issuelinks/"
-      target="_blank">jiraGetRemoteIssueLinks
+      target="_blank">jiraGetIssueRemoteLinks
     </a> for more information.
     </p>
   </f:block>

--- a/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueRemoteLinkStep/config.jelly
+++ b/src/main/resources/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueRemoteLinkStep/config.jelly
@@ -8,7 +8,7 @@
     <p>No snippet generation available except some advanced default options.
       <br/>See <a
         href="https://jenkinsci.github.io/jira-steps-plugin/steps/issuelink/jira_new_remote_issuelink/"
-        target="_blank">jiraNewRemoteIssueLink
+        target="_blank">jiraNewIssueRemoteLink
       </a> for more information.
     </p>
   </f:block>


### PR DESCRIPTION
# Description

The documentation of the `RemoteIssueLink` method is wrong cause they actually are called `IssueRemoteLink`

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
