### PR TITLE
Under certain conditions JIRA is responding with http 307 to requests…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,8 @@
     <!-- Be careful of upgrading this to later versions, cause pipeline plugins depend on this version. -->
     <jackson2.version>2.10.3</jackson2.version>
     <retrofit2.version>2.8.1</retrofit2.version>
+    <okhttp.version>4.6.0</okhttp.version>
+    <kotlinstdlib.version>1.3.72</kotlinstdlib.version>
     <lombok.version>1.18.12</lombok.version>
     <signpost.oauth.version>1.2.1.2</signpost.oauth.version>
     <google.oauth.version>1.22.0</google.oauth.version>
@@ -132,6 +134,37 @@
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>adapter-rxjava</artifactId>
       <version>${retrofit2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${okhttp.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlinstdlib.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>${kotlinstdlib.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/RequestAdapter.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/RequestAdapter.java
@@ -1,5 +1,6 @@
 package org.thoughtslive.jenkins.plugins.jira.login;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ public class RequestAdapter implements HttpRequest {
   }
 
   @Override
+  @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
   public String getContentType() {
     if (request.body() != null) {
       return (request.body().contentType() != null) ? request.body().contentType().toString()
@@ -40,6 +42,7 @@ public class RequestAdapter implements HttpRequest {
   }
 
   @Override
+  @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
   public InputStream getMessagePayload() throws IOException {
     if (request.body() == null) {
       return null;


### PR DESCRIPTION
okhttp only follows them starting version 4.6.0 (https://github.com/square/okhttp/pull/5990)

Ignored findbugs issues, since null was always a valid return value anyhow.