### PR TITLE
Let's access exception to diagnose issues

### DIFF
--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/ResponseData.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/ResponseData.java
@@ -31,4 +31,7 @@ public class ResponseData<T> implements Serializable {
 
   @Whitelisted
   private T data;
+
+  @Whitelisted
+  private String stacktrace;
 }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/util/Common.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/util/Common.java
@@ -3,6 +3,9 @@ package org.thoughtslive.jenkins.plugins.jira.util;
 import hudson.EnvVars;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 import org.thoughtslive.jenkins.plugins.jira.api.ResponseData;
 import org.thoughtslive.jenkins.plugins.jira.api.ResponseData.ResponseDataBuilder;
 import retrofit2.Response;
@@ -95,7 +98,8 @@ public class Common {
   public static <T> ResponseData<T> buildErrorResponse(final Exception e) {
     final ResponseDataBuilder<T> builder = ResponseData.builder();
     final String errorMessage = getRootCause(e).getMessage();
-    return builder.successful(false).code(-1).error(errorMessage).build();
+    final String stacktrace = getStackTrace(e);
+    return builder.successful(false).code(-1).error(errorMessage).stacktrace(stacktrace).build();
   }
 
   /**
@@ -108,5 +112,13 @@ public class Common {
       return getRootCause(throwable.getCause());
     }
     return throwable;
+  }
+
+  public static String getStackTrace(Throwable throwable) {
+    StringWriter buffer = new StringWriter();
+    PrintWriter writer = new PrintWriter(buffer);
+    throwable.printStackTrace(writer);
+    writer.flush();
+    return buffer.toString();
   }
 }


### PR DESCRIPTION
# Description

After plugin upgrades, I have the following error:

```
Error Code: -1
Error Message: Invalid input length 849
```

As error stack is suppressed, I have no way to diagnose the issue. So I modified POJO to let access at least to stack trace.

I run `mvn verify` to validate my changes.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
