### PR TITLE
Enable every kind of UsernamePasswordCredentials

### DIFF
--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/Site.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/Site.java
@@ -5,9 +5,9 @@ import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
-import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
@@ -220,7 +220,7 @@ public class Site extends AbstractDescribableImpl<Site> {
       Authentication authentication = getAuthentication(item);
       List<DomainRequirement> domainRequirements = URIRequirementBuilder.fromUri(url).build();
       CredentialsMatcher always = CredentialsMatchers.always();
-      Class<? extends StandardUsernameCredentials> type = UsernamePasswordCredentialsImpl.class;
+      Class type = UsernamePasswordCredentials.class;
 
       result.includeEmptyValue();
       if (item != null) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/SigningInterceptor.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/SigningInterceptor.java
@@ -2,7 +2,7 @@ package org.thoughtslive.jenkins.plugins.jira.login;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
-import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.security.ACL;
 import java.io.IOException;
@@ -62,9 +62,9 @@ public class SigningInterceptor implements Interceptor {
           .findFirst() //
           .orElseThrow(() -> new IllegalStateException(Messages.Site_invalidCredentialsId()));
       String credentials = credentialsId.getUsername();
-      if (credentialsId instanceof UsernamePasswordCredentialsImpl) {
+      if (credentialsId instanceof UsernamePasswordCredentials) {
         credentials +=
-            ":" + ((UsernamePasswordCredentialsImpl) credentialsId).getPassword().getPlainText();
+            ":" + ((UsernamePasswordCredentials) credentialsId).getPassword().getPlainText();
       }
       String encodedHeader =
           "Basic " + new String(Base64.getEncoder().encode(credentials.getBytes()));


### PR DESCRIPTION
Removing the limitation on one specific Impl.

# Description
We use hashicorps vault UsernamePasswordCredentials. Due to limited implemtenation this does not work.

# Submitter checklist
[-] Link to JIRA ticket in description, if appropriate. => there is no jira issue ...
[x] Change is code complete. => complete from my point of view
[-] Appropriate unit or acceptance tests or explanation to why this change has no tests. => => unable to find src/test/java/org/thoughtslive/jenkins/plugins/jira/SiteTest.java - so I am unsure where to find a good place for a unit test.
[x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below. 

## How to review:
1. Install the change
2. create an other kind of UsernamePassowrd-Credential e.g. Vault-UsernamePassowrd-Credential
3. Configure the jira-steps-plugin using auth "CREDENTIAL" => the created Vault-UsernamePassowrd-Credential should be selectable.
4. Test Connection => test should accept your credentials.

# Reviewer checklist
[] Run the changes and verified the change matches the issue description.
[] Reviewed the code.
[] Verified that the appropriate tests have been written or valid explanation given.
[] If applicable, tested by installing this plugin on the Jenkins instance.
