### PR TITLE
use okhttp version following 307/308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
     <retrofit2.version>2.9.0</retrofit2.version>
     <signpost.oauth.version>2.1.1</signpost.oauth.version>
     <maven.javadoc.skip>true</maven.javadoc.skip>
+    <okhttp.version>4.9.3</okhttp.version>
+    <kotlinstdlib.version>1.3.72</kotlinstdlib.version>
   </properties>
   <licenses>
     <license>
@@ -106,6 +108,37 @@
       <artifactId>adapter-rxjava</artifactId>
       <groupId>com.squareup.retrofit2</groupId>
       <version>${retrofit2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${okhttp.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlinstdlib.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>${kotlinstdlib.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <artifactId>converter-jackson</artifactId>

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/RequestAdapter.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/RequestAdapter.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import oauth.signpost.http.HttpRequest;
 import okhttp3.Request;
 import okio.Buffer;
@@ -26,6 +28,7 @@ public class RequestAdapter implements HttpRequest {
   }
 
   @Override
+  @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
   public String getContentType() {
     if (request.body() != null) {
       return (request.body().contentType() != null) ? request.body().contentType().toString()
@@ -40,6 +43,7 @@ public class RequestAdapter implements HttpRequest {
   }
 
   @Override
+  @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
   public InputStream getMessagePayload() throws IOException {
     if (request.body() == null) {
       return null;


### PR DESCRIPTION
# Description

JIRA (at least we see regularly) issues a 307 to clients. 
So it is not reproducible in a sense, that i can provide a step-by-step guide.

Okhttp only follows them starting version 4.6.0 (https://github.com/square/okhttp/pull/5990)
Ignored findbugs issues, since null was always a valid return value anyhow.

No test specifically added, cause it is not a matter of the plugin, but the dependency.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
