### PR TITLE
[SECURITY-2774] Fix private key stored in plain text

### DIFF
--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/SigningInterceptor.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/SigningInterceptor.java
@@ -43,7 +43,7 @@ public class SigningInterceptor implements Interceptor {
     } else if (Site.LoginType.OAUTH.name().equalsIgnoreCase(jiraSite.getLoginType())) {
       Request request = chain.request();
       OAuthConsumer consumer =
-          new OAuthConsumer(jiraSite.getConsumerKey(), jiraSite.getPrivateKey());
+          new OAuthConsumer(jiraSite.getConsumerKey(), jiraSite.getPrivateKeySecret().getPlainText());
       consumer.setTokenWithSecret(jiraSite.getToken().getPlainText(),
           jiraSite.getSecret().getPlainText());
       consumer.setMessageSigner(new RsaSha1MessageSigner());

--- a/src/main/resources/org/thoughtslive/jenkins/plugins/jira/Site/config.jelly
+++ b/src/main/resources/org/thoughtslive/jenkins/plugins/jira/Site/config.jelly
@@ -42,8 +42,8 @@
         <f:entry field="consumerKey" title="Consumer Key">
           <f:textbox/>
         </f:entry>
-        <f:entry field="privateKey" title="Private Key">
-          <f:expandableTextbox/>
+        <f:entry field="privateKeySecret" title="Private Key">
+          <f:secretTextarea/>
         </f:entry>
         <f:entry field="secret" title="Secret">
           <f:password/>


### PR DESCRIPTION
# Description

See [JENKINS-71912](https://issues.jenkins.io/browse/JENKINS-71912) / [SECURITY-2774](https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2774)

Implemented migration of plain-text private key to Secret using [`XStream2.PassthruConverter`](https://www.jenkins.io/doc/developer/persistence/backward-compatibility/).

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
