### PR TITLE
Enable queryParams for jiraGetIssue

### DIFF
--- a/hugo/content/changelog.md
+++ b/hugo/content/changelog.md
@@ -6,7 +6,7 @@ lastmodifierdisplayname = "Naresh Rayapati"
 +++
 
 * #### **1.6.1** (Unreleased)
-
+  * [JENKINS-44398](https://issues.jenkins.io/browse/JENKINS-44398) Enable queryParams for jiraGetIssue.
 
 * #### **1.6.0**
   * [JENKINS-47199](https://issues.jenkins-ci.org/browse/JENKINS-47199) Use Jenkins Credential storage for JIRA credentials.

--- a/hugo/content/steps/issue/jira_get_issue.md
+++ b/hugo/content/steps/issue/jira_get_issue.md
@@ -14,6 +14,7 @@ This step queries a particular issue from the provided JIRA site.
 #### Input
 
 * **idOrKey** - Issue id or key.
+* **queryParams** - Optional. Map of query parameters.
 * **site** - Optional, default: `JIRA_SITE` environment variable.
 * **failOnError** - Optional. default: `true`.
 
@@ -39,7 +40,8 @@ For more information about input, please refer to the model objects in the [API]
     ```groovy
     node {
       stage('JIRA') {
-        def issue = jiraGetIssue idOrKey: 'TEST-1'
+        def queryParams = [expand: 'changelog']
+        def issue = jiraGetIssue idOrKey: 'TEST-1', queryParams: queryParams
         echo issue.data.toString()
       }
     }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraEndPoints.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraEndPoints.java
@@ -44,7 +44,8 @@ public interface JiraEndPoints {
 
   // Issue
   @GET("rest/api/2/issue/{issueIdOrKey}")
-  Call<Object> getIssue(@Path("issueIdOrKey") String issueIdOrKey);
+  Call<Object> getIssue(@Path("issueIdOrKey") String issueIdOrKey,
+      @QueryMap Map<String, String> queryMap);
 
   @POST("rest/api/2/issue")
   Call<Object> createIssue(@Body Object issue);

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraService.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraService.java
@@ -171,9 +171,10 @@ public class JiraService {
    * @param issueIdOrKey issue id or key.
    * @return issue.
    */
-  public ResponseData<Object> getIssue(final String issueIdOrKey) {
+  public ResponseData<Object> getIssue(final String issueIdOrKey,
+      final Map<String, String> queryParams) {
     try {
-      return parseResponse(jiraEndPoints.getIssue(issueIdOrKey).execute());
+      return parseResponse(jiraEndPoints.getIssue(issueIdOrKey, queryParams).execute());
     } catch (Exception e) {
       return buildErrorResponse(e);
     }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueStep.java
@@ -70,7 +70,7 @@ public class GetIssueStep extends BasicJiraStep {
       if (response == null) {
         logger.println(
             "JIRA: Site - " + siteName + " - Querying issue with idOrKey: " + step.getIdOrKey());
-        response = jiraService.getIssue(step.getIdOrKey());
+        response = jiraService.getIssue(step.getIdOrKey(), step.getQueryParams());
       }
 
       return logResponse(response);

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueStepTest.java
@@ -2,6 +2,7 @@ package org.thoughtslive.jenkins.plugins.jira.steps;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -9,6 +10,8 @@ import static org.mockito.Mockito.when;
 
 import hudson.AbortException;
 import java.io.IOException;
+import java.util.HashMap;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.thoughtslive.jenkins.plugins.jira.BaseTest;
@@ -28,7 +31,7 @@ public class GetIssueStepTest extends BaseTest {
   public void setup() throws IOException, InterruptedException {
 
     final ResponseDataBuilder<Object> builder = ResponseData.builder();
-    when(jiraServiceMock.getIssue(anyString()))
+    when(jiraServiceMock.getIssue(anyString(), any()))
         .thenReturn(builder.successful(true).code(200).message("Success").build());
   }
 
@@ -53,7 +56,7 @@ public class GetIssueStepTest extends BaseTest {
     stepExecution.run();
 
     // Assert Test
-    verify(jiraServiceMock, times(1)).getIssue("TEST-1");
+    verify(jiraServiceMock, times(1)).getIssue("TEST-1", new HashMap<>());
     assertThat(step.isFailOnError()).isEqualTo(true);
   }
 }


### PR DESCRIPTION
See [JENKINS-44398](https://issues.jenkins.io/browse/JENKINS-44398).

The implementation is the same as already present for jiraEditIssue.

The initial motivation was to retrieve changelogs for issues - also mentioned in [JENKINS-44398](https://issues.jenkins.io/browse/JENKINS-44398). This change enables query parameters for the Get Issue API call:
https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-get-request-Query%20parameters

I tested this locally with a local Jira using a simple Pipeline:
```groovy
def issue = jiraGetIssue idOrKey: 'PRJ-1', site: 'jira', queryParams: [expand:'changelog']
echo issue.data.toString()
```
Running the pipeline without the change did not retrieve the changelog as part of the response. The changelog was retrieved after the change. I also spot checked other query parameters, e.g:
```groovy
def issue = jiraGetIssue idOrKey: 'PRJ-1', site: 'jira', queryParams: [expand:'changelog', fields:'issuetype']
echo issue.data.toString()
```

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
