### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,11 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
 buildPlugin(
-  useContainerAgent: true,
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 11]
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>plugin</artifactId>
     <groupId>org.jenkins-ci.plugins</groupId>
-    <version>4.54</version>
+    <version>5.7</version>
   </parent>
   <artifactId>jira-steps</artifactId>
   <version>${revision}.${changelist}</version>
@@ -18,13 +18,13 @@
     <changelist>999999-SNAPSHOT</changelist>
     <java.level>8</java.level>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.361</jenkins.baseline>
+    <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <assertj-core.version>3.27.3</assertj-core.version>
     <google.oauth.version>1.37.0</google.oauth.version>
     <lombok.version>1.18.36</lombok.version>
-    <retrofit2.version>2.9.0</retrofit2.version>
+    <retrofit2.version>2.11.0</retrofit2.version>
     <signpost.oauth.version>2.1.1</signpost.oauth.version>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
@@ -32,7 +32,7 @@
     <license>
       <distribution>repo</distribution>
       <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
   <organization>
@@ -76,7 +76,17 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <scope>import</scope>
         <type>pom</type>
-        <version>1763.v092b_8980a_f5e</version>
+        <version>4136.vca_c3202a_7fd1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>2.28.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.j2objc</groupId>
+        <artifactId>j2objc-annotations</artifactId>
+        <version>3.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -102,7 +112,8 @@
     <dependency>
       <artifactId>jackson-datatype-joda</artifactId>
       <groupId>com.fasterxml.jackson.datatype</groupId>
-      <version>2.13.3</version>
+      <!-- must match jackson2-api version -->
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <artifactId>adapter-rxjava</artifactId>
@@ -139,7 +150,7 @@
 
     <!-- Test Dependencies -->
     <dependency>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <groupId>org.mockito</groupId>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/JiraStepsConfig.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/JiraStepsConfig.java
@@ -5,6 +5,8 @@ import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.CopyOnWriteList;
+
+import java.io.Serial;
 import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -15,7 +17,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Represents JIRA Global Configuration.
@@ -63,8 +65,9 @@ public class JiraStepsConfig extends AbstractDescribableImpl<JiraStepsConfig> {
   public static final class ConfigDescriptorImpl extends Descriptor<JiraStepsConfig>
       implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 6174559183832237318L;
-    private final CopyOnWriteList<Site> sites = new CopyOnWriteList<Site>();
+    private final CopyOnWriteList<Site> sites = new CopyOnWriteList<>();
 
     public ConfigDescriptorImpl() {
       super(JiraStepsConfig.class);
@@ -85,7 +88,7 @@ public class JiraStepsConfig extends AbstractDescribableImpl<JiraStepsConfig> {
     }
 
     @Override
-    public JiraStepsConfig newInstance(@Nonnull final StaplerRequest req, final JSONObject formData)
+    public JiraStepsConfig newInstance(@Nonnull final StaplerRequest2 req, final JSONObject formData)
         throws FormException {
       JiraStepsConfig jiraConfig = req.bindJSON(JiraStepsConfig.class, formData);
       if (jiraConfig.siteName == null) {
@@ -95,7 +98,7 @@ public class JiraStepsConfig extends AbstractDescribableImpl<JiraStepsConfig> {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject formData) {
+    public boolean configure(StaplerRequest2 req, JSONObject formData) {
       Stapler.CONVERT_UTILS.deregister(java.net.URL.class);
       Stapler.CONVERT_UTILS.register(new EmptyFriendlyURLConverter(), java.net.URL.class);
       sites.replaceBy(req.bindJSONToList(Site.class, formData.get("sites")));
@@ -107,7 +110,7 @@ public class JiraStepsConfig extends AbstractDescribableImpl<JiraStepsConfig> {
     public static class EmptyFriendlyURLConverter implements Converter {
 
       @Override
-      public Object convert(@SuppressWarnings("rawtypes") Class aClass, Object o) {
+      public Object convert(Class aClass, Object o) {
         if (o == null || "".equals(o) || "null".equals(o)) {
           return null;
         }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/Site.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/Site.java
@@ -5,7 +5,6 @@ import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
-import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
@@ -35,7 +34,6 @@ import jenkins.model.Jenkins;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.java.Log;
-import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -44,6 +42,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
+import org.springframework.security.core.Authentication;
 import org.thoughtslive.jenkins.plugins.jira.api.ResponseData;
 import org.thoughtslive.jenkins.plugins.jira.service.JiraService;
 
@@ -222,7 +221,7 @@ public class Site extends AbstractDescribableImpl<Site> {
       }
 
       List<DomainRequirement> domainRequirements = URIRequirementBuilder.fromUri(url).build();
-      if (CredentialsProvider.listCredentials(StandardUsernameCredentials.class, item,
+      if (CredentialsProvider.listCredentialsInItem(StandardUsernameCredentials.class, item,
               getAuthentication(item), domainRequirements, CredentialsMatchers.withId(credentialsId))
           .isEmpty()) {
         return FormValidation.error(Messages.Site_invalidCredentialsId());
@@ -251,7 +250,7 @@ public class Site extends AbstractDescribableImpl<Site> {
       Authentication authentication = getAuthentication(item);
       List<DomainRequirement> domainRequirements = URIRequirementBuilder.fromUri(url).build();
       CredentialsMatcher always = CredentialsMatchers.always();
-      Class type = UsernamePasswordCredentials.class;
+      Class<StandardUsernameCredentials> type = StandardUsernameCredentials.class;
 
       result.includeEmptyValue();
       if (item != null) {
@@ -263,7 +262,7 @@ public class Site extends AbstractDescribableImpl<Site> {
     }
 
     protected Authentication getAuthentication(Item item) {
-      return item instanceof Queue.Task ? Tasks.getAuthenticationOf((Queue.Task) item) : ACL.SYSTEM;
+      return item instanceof Queue.Task task ? Tasks.getAuthenticationOf2(task) : ACL.SYSTEM2;
     }
 
     @POST

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/ResponseData.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/ResponseData.java
@@ -1,5 +1,6 @@
 package org.thoughtslive.jenkins.plugins.jira.api;
 
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +16,7 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 @Builder
 public class ResponseData<T> implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = 7846727738826103343L;
 
   @Whitelisted

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/IssueInput.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/IssueInput.java
@@ -3,6 +3,8 @@ package org.thoughtslive.jenkins.plugins.jira.api.input;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -19,6 +21,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 @Builder
 public class IssueInput implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = 536532573196612271L;
 
   @JsonProperty("update")

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/IssuesInput.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/api/input/IssuesInput.java
@@ -3,6 +3,8 @@ package org.thoughtslive.jenkins.plugins.jira.api.input;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -19,6 +21,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 @Builder
 public class IssuesInput implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = 3299430745665528801L;
 
   @JsonProperty("issueUpdates")

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/OAuthConsumer.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/OAuthConsumer.java
@@ -4,8 +4,11 @@ import oauth.signpost.AbstractOAuthConsumer;
 import oauth.signpost.http.HttpRequest;
 import okhttp3.Request;
 
+import java.io.Serial;
+
 public class OAuthConsumer extends AbstractOAuthConsumer {
 
+  @Serial
   private static final long serialVersionUID = 1364436370216401109L;
 
   public OAuthConsumer(String consumerKey, String consumerSecret) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/RequestAdapter.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/RequestAdapter.java
@@ -18,7 +18,7 @@ public class RequestAdapter implements HttpRequest {
 
   @Override
   public Map<String, String> getAllHeaders() {
-    HashMap<String, String> headers = new HashMap<String, String>();
+    HashMap<String, String> headers = new HashMap<>();
     for (String key : request.headers().names()) {
       headers.put(key, request.header(key));
     }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/RsaSha1MessageSigner.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/RsaSha1MessageSigner.java
@@ -1,10 +1,13 @@
 package org.thoughtslive.jenkins.plugins.jira.login;
 
 import com.google.api.client.auth.oauth.OAuthRsaSigner;
-import com.google.api.client.util.Base64;
+
+import java.io.Serial;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+
 import oauth.signpost.exception.OAuthMessageSignerException;
 import oauth.signpost.http.HttpParameters;
 import oauth.signpost.http.HttpRequest;
@@ -13,6 +16,7 @@ import oauth.signpost.signature.SignatureBaseString;
 
 public class RsaSha1MessageSigner extends OAuthMessageSigner {
 
+  @Serial
   private static final long serialVersionUID = -1777278892400172839L;
 
   @Override
@@ -25,7 +29,7 @@ public class RsaSha1MessageSigner extends OAuthMessageSigner {
       throws OAuthMessageSignerException {
 
     final OAuthRsaSigner signer = new OAuthRsaSigner();
-    final byte[] privateBytes = Base64.decodeBase64(getConsumerSecret());
+    final byte[] privateBytes = Base64.getDecoder().decode(getConsumerSecret());
     final PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateBytes);
 
     try {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/SigningInterceptor.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/SigningInterceptor.java
@@ -55,16 +55,16 @@ public class SigningInterceptor implements Interceptor {
     } else if (Site.LoginType.CREDENTIAL.name().equalsIgnoreCase(jiraSite.getLoginType())) {
       StandardUsernameCredentials credentialsId = null;
       // credentials is saved in global configuration, there is no context there during test connection so SYSTEM access is used
-      credentialsId = CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class,
-              Jenkins.get(), ACL.SYSTEM, Collections.emptyList()) //
+      credentialsId = CredentialsProvider.lookupCredentialsInItemGroup(StandardUsernameCredentials.class,
+              Jenkins.get(), ACL.SYSTEM2, Collections.emptyList()) //
           .stream() //
           .filter(c -> c.getId().equals(jiraSite.getCredentialsId())) //
           .findFirst() //
           .orElseThrow(() -> new IllegalStateException(Messages.Site_invalidCredentialsId()));
       String credentials = credentialsId.getUsername();
-      if (credentialsId instanceof UsernamePasswordCredentials) {
+      if (credentialsId instanceof UsernamePasswordCredentials usernamePasswordCredentials) {
         credentials +=
-            ":" + ((UsernamePasswordCredentials) credentialsId).getPassword().getPlainText();
+            ":" + usernamePasswordCredentials.getPassword().getPlainText();
       }
       String encodedHeader =
           "Basic " + new String(Base64.getEncoder().encode(credentials.getBytes()));

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraService.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraService.java
@@ -63,7 +63,7 @@ public class JiraService {
             proxyConfiguration.port);
         Authenticator proxyAuthenticator = (route, response) -> {
           String credential = Credentials.basic(proxyConfiguration.getUserName(),
-              proxyConfiguration.getPassword());
+              proxyConfiguration.getSecretPassword().getPlainText());
           return response.request().newBuilder()
               .header("Proxy-Authorization", credential)
               .build();
@@ -202,7 +202,7 @@ public class JiraService {
 
   public ResponseData<Void> assignIssue(final String issueIdorKey, final String userName) {
     try {
-      Map input = Maps.newHashMap();
+      Map<Object, Object> input = Maps.newHashMap();
       input.put("name", userName);
       return parseResponse(
           jiraEndPoints

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddCommentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddCommentStep.java
@@ -6,6 +6,8 @@ import com.google.common.collect.ImmutableMap;
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -21,18 +23,17 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class AddCommentStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 8523118063993121080L;
 
-  @Getter
   private final String idOrKey;
 
   @Deprecated
-  @Getter
   private final String comment;
 
-  @Getter
   @DataBoundSetter
   private Object input;
 
@@ -64,6 +65,7 @@ public class AddCommentStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 462945562138805176L;
 
     private final AddCommentStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddWatcherStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddWatcherStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,14 +20,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class AddWatcherStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 6417829072320454268L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final String userName;
 
   @DataBoundConstructor
@@ -55,6 +57,7 @@ public class AddWatcherStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Void>> {
 
+    @Serial
     private static final long serialVersionUID = 937198146137084269L;
 
     private final AddWatcherStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignIssueStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,17 +20,16 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class AssignIssueStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -7552691123209663987L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final String userName;
 
-  @Getter
   private final String accountId;
 
   @DataBoundConstructor
@@ -60,6 +61,7 @@ public class AssignIssueStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Void>> {
 
+    @Serial
     private static final long serialVersionUID = -7608114889563811741L;
 
     private final AssignIssueStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignableUserSearchStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignableUserSearchStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -19,22 +21,19 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class AssignableUserSearchStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -7754102811625753132L;
 
-  @Getter
   private String project;
 
-  @Getter
   private String issueKey;
-  @Getter
   @DataBoundSetter
   private String queryStr;
-  @Getter
   @DataBoundSetter
   private int startAt = 0;
-  @Getter
   @DataBoundSetter
   private int maxResults = 1000;
 
@@ -66,6 +65,7 @@ public class AssignableUserSearchStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 3640953129479843111L;
 
     private final AssignableUserSearchStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/BasicJiraStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/BasicJiraStep.java
@@ -2,6 +2,7 @@ package org.thoughtslive.jenkins.plugins.jira.steps;
 
 import hudson.Extension;
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -16,23 +17,21 @@ import org.kohsuke.stapler.DataBoundSetter;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public abstract class BasicJiraStep extends Step implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = 7268920801605705697L;
 
-  @Getter
   @DataBoundSetter
   private String site;
 
-  @Getter
   @DataBoundSetter
   private boolean failOnError = true;
 
-  @Getter
   @DataBoundSetter
   private boolean auditLog = true;
 
-  @Getter
   @DataBoundSetter
   private Map<String, String> queryParams = new HashMap<>();
 

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteAttachmentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteAttachmentStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,11 +20,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class DeleteAttachmentStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -4661648934764886451L;
 
-  @Getter
   private final String id;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class DeleteAttachmentStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -742172771459279821L;
 
     private final DeleteAttachmentStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueLinkStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueLinkStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,10 +20,11 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class DeleteIssueLinkStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -4252560961571411897L;
-  @Getter
   private final String id;
 
   @DataBoundConstructor
@@ -51,6 +54,7 @@ public class DeleteIssueLinkStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 325576266548671174L;
 
     private final DeleteIssueLinkStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinkStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinkStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,14 +20,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class DeleteIssueRemoteLinkStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 3529709240318435576L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final String linkId;
 
   @DataBoundConstructor
@@ -56,6 +58,7 @@ public class DeleteIssueRemoteLinkStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 325576266548671174L;
 
     private final DeleteIssueRemoteLinkStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinksStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinksStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,14 +20,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class DeleteIssueRemoteLinksStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 3529709240318435576L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final String globalId;
 
   @DataBoundConstructor
@@ -56,6 +58,7 @@ public class DeleteIssueRemoteLinksStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 325576266548671174L;
 
     private final DeleteIssueRemoteLinksStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DownloadAttachmentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DownloadAttachmentStep.java
@@ -7,6 +7,8 @@ import hudson.FilePath;
 import hudson.Util;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Serial;
+
 import lombok.Getter;
 import okhttp3.ResponseBody;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -22,17 +24,16 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class DownloadAttachmentStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 6317067114642701582L;
 
-  @Getter
   private final String id;
 
-  @Getter
   private final String file;
 
-  @Getter
   private boolean override;
 
   @DataBoundConstructor
@@ -64,6 +65,7 @@ public class DownloadAttachmentStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -1459989930759928081L;
 
     private final DownloadAttachmentStep step;
@@ -138,7 +140,7 @@ public class DownloadAttachmentStep extends BasicJiraStep {
             }
             responseData.setData(null);
           } else {
-            final ResponseData.ResponseDataBuilder builder = ResponseData.builder();
+            final ResponseData.ResponseDataBuilder<Object> builder = ResponseData.builder();
             builder.successful(response.isSuccessful()).code(response.getCode())
                 .message(response.getMessage()).error(response.getError());
             return builder.build();

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditCommentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditCommentStep.java
@@ -6,6 +6,8 @@ import com.google.common.collect.ImmutableMap;
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -21,21 +23,19 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class EditCommentStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -6330276534463853856L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final String commentId;
 
   @Deprecated
-  @Getter
   private final String comment;
 
-  @Getter
   @DataBoundSetter
   private Object input;
 
@@ -68,6 +68,7 @@ public class EditCommentStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -7000442485946132663L;
 
     private final EditCommentStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditComponentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditComponentStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,14 +20,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class EditComponentStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 6528605492208170984L;
 
-  @Getter
   private final String id;
 
-  @Getter
   private final Object component;
 
   @DataBoundConstructor
@@ -55,6 +57,7 @@ public class EditComponentStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Void>> {
 
+    @Serial
     private static final long serialVersionUID = 6229925264184593843L;
 
     private final EditComponentStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditIssueStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,14 +20,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class EditIssueStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -4542562652787306504L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final Object issue;
 
   @DataBoundConstructor
@@ -55,6 +57,7 @@ public class EditIssueStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -4127725325057889625L;
 
     private final EditIssueStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditVersionStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditVersionStep.java
@@ -4,6 +4,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 
 import hudson.Extension;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -17,14 +19,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class EditVersionStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -2029161404995143511L;
 
-  @Getter
   private final String id;
 
-  @Getter
   private final Object version;
 
   @DataBoundConstructor
@@ -54,6 +56,7 @@ public class EditVersionStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Void>> {
 
+    @Serial
     private static final long serialVersionUID = -5317591315201131186L;
 
     private final EditVersionStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetAttachmentInfoStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetAttachmentInfoStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,11 +20,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetAttachmentInfoStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -5058732591554743625L;
 
-  @Getter
   private final String id;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class GetAttachmentInfoStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -5187767326395467171L;
 
     private final GetAttachmentInfoStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetCommentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetCommentStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,14 +20,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetCommentStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -3225315653270733874L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final String commentId;
 
   @DataBoundConstructor
@@ -56,6 +58,7 @@ public class GetCommentStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 6956525377031302225L;
 
     private final GetCommentStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetCommentsStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetCommentsStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,11 +20,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetCommentsStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 3545679919575498803L;
 
-  @Getter
   private final String idOrKey;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class GetCommentsStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -9014641944773640463L;
 
     private final GetCommentsStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetComponentIssueCountStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetComponentIssueCountStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,11 +20,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetComponentIssueCountStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -4668092703770930031L;
 
-  @Getter
   private final String id;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class GetComponentIssueCountStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 6380332864146135606L;
 
     private final GetComponentIssueCountStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetComponentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetComponentStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,11 +20,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetComponentStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 387862257528432812L;
 
-  @Getter
   private final String id;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class GetComponentStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 211769231724671924L;
 
     private final GetComponentStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetFieldsStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetFieldsStep.java
@@ -2,6 +2,8 @@ package org.thoughtslive.jenkins.plugins.jira.steps;
 
 import hudson.Extension;
 import java.io.IOException;
+import java.io.Serial;
+
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -16,6 +18,7 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  */
 public class GetFieldsStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 2689031885988669114L;
 
   @DataBoundConstructor
@@ -44,6 +47,7 @@ public class GetFieldsStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -5702548715847670073L;
 
     private final GetFieldsStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueLinkStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueLinkStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,10 +20,11 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetIssueLinkStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -4252560961571411897L;
-  @Getter
   private final String id;
 
   @DataBoundConstructor
@@ -51,6 +54,7 @@ public class GetIssueLinkStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 325576266548671174L;
 
     private final GetIssueLinkStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueLinkTypesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueLinkTypesStep.java
@@ -2,6 +2,8 @@ package org.thoughtslive.jenkins.plugins.jira.steps;
 
 import hudson.Extension;
 import java.io.IOException;
+import java.io.Serial;
+
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -16,6 +18,7 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  */
 public class GetIssueLinkTypesStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 7300279362207875286L;
 
   @DataBoundConstructor
@@ -44,6 +47,7 @@ public class GetIssueLinkTypesStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -1387617043703686867L;
 
     private final GetIssueLinkTypesStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinkStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinkStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,14 +20,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetIssueRemoteLinkStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 3529709240318435576L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final String linkId;
 
   @DataBoundConstructor
@@ -56,6 +58,7 @@ public class GetIssueRemoteLinkStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 325576266548671174L;
 
     private final GetIssueRemoteLinkStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinksStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinksStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,14 +20,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetIssueRemoteLinksStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 3529709240318435576L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final String globalId;
 
   @DataBoundConstructor
@@ -56,6 +58,7 @@ public class GetIssueRemoteLinksStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 325576266548671174L;
 
     private final GetIssueRemoteLinksStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,11 +20,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetIssueStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -8758698444697767020L;
 
-  @Getter
   private final String idOrKey;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class GetIssueStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 6898696015602575211L;
 
     private final GetIssueStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueTransitionsStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueTransitionsStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,11 +20,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetIssueTransitionsStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 76788852720885769L;
 
-  @Getter
   private final String idOrKey;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class GetIssueTransitionsStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 4731872444274410275L;
 
     private final GetIssueTransitionsStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueWatchesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueWatchesStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,11 +20,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetIssueWatchesStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -4095433082021536972L;
 
-  @Getter
   private final String idOrKey;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class GetIssueWatchesStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -2511162263195215296L;
 
     private final GetIssueWatchesStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectComponentsStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectComponentsStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,11 +20,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetProjectComponentsStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 1831738736953963099L;
 
-  @Getter
   private final String idOrKey;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class GetProjectComponentsStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -1946537791588473196L;
 
     private final GetProjectComponentsStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectStatusesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectStatusesStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,11 +20,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetProjectStatusesStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -402279833026508134L;
 
-  @Getter
   private final String idOrKey;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class GetProjectStatusesStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -1946537791588473196L;
 
     private final GetProjectStatusesStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,11 +20,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetProjectStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 8326344234130259321L;
 
-  @Getter
   private final String idOrKey;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class GetProjectStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -1946537791588473196L;
 
     private final GetProjectStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectVersionsStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectVersionsStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,11 +20,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetProjectVersionsStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 3692152135588867038L;
 
-  @Getter
   private final String idOrKey;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class GetProjectVersionsStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -1946537791588473196L;
 
     private final GetProjectVersionsStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectsStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectsStep.java
@@ -2,6 +2,8 @@ package org.thoughtslive.jenkins.plugins.jira.steps;
 
 import hudson.Extension;
 import java.io.IOException;
+import java.io.Serial;
+
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -16,6 +18,7 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  */
 public class GetProjectsStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 2689031885988669114L;
 
   @DataBoundConstructor
@@ -44,6 +47,7 @@ public class GetProjectsStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -5702548715847670073L;
 
     private final GetProjectsStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetServerInfoStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetServerInfoStep.java
@@ -2,6 +2,7 @@ package org.thoughtslive.jenkins.plugins.jira.steps;
 
 import hudson.Extension;
 import java.io.IOException;
+import java.io.Serial;
 import java.util.Map;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -17,6 +18,7 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  */
 public class GetServerInfoStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -439860819128513604L;
 
   @DataBoundConstructor
@@ -44,6 +46,7 @@ public class GetServerInfoStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Map<String, Object>>> {
 
+    @Serial
     private static final long serialVersionUID = -3058199854899051131L;
 
     private final GetServerInfoStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetVersionStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetVersionStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,10 +20,11 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class GetVersionStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -4252560961571411897L;
-  @Getter
   private final String id;
 
   @DataBoundConstructor
@@ -51,6 +54,7 @@ public class GetVersionStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 325576266548671174L;
 
     private final GetVersionStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/JqlSearchStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/JqlSearchStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -19,22 +21,20 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class JqlSearchStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -7754102811625753132L;
 
-  @Getter
   private final String jql;
 
-  @Getter
   @DataBoundSetter
   private int startAt = 0;
 
-  @Getter
   @DataBoundSetter
   private int maxResults = 1000;
 
-  @Getter
   @DataBoundSetter
   private Object fields;
 
@@ -64,6 +64,7 @@ public class JqlSearchStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 3640953129479843111L;
 
     private final JqlSearchStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/LinkIssuesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/LinkIssuesStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -19,20 +21,18 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class LinkIssuesStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -1881920733234295481L;
 
-  @Getter
   private final String type;
 
-  @Getter
   private final String inwardKey;
 
-  @Getter
   private final String outwardKey;
   // Comment is optional.
-  @Getter
   @DataBoundSetter
   private String comment;
 
@@ -64,6 +64,7 @@ public class LinkIssuesStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Void>> {
 
+    @Serial
     private static final long serialVersionUID = -1666683149182699538L;
 
     private final LinkIssuesStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewComponentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewComponentStep.java
@@ -2,6 +2,8 @@ package org.thoughtslive.jenkins.plugins.jira.steps;
 
 import hudson.Extension;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -16,11 +18,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class NewComponentStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 4939494003115851145L;
 
-  @Getter
   private final Object component;
 
   @DataBoundConstructor
@@ -49,6 +52,7 @@ public class NewComponentStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -6324419009842564119L;
 
     private final NewComponentStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueRemoteLinkStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueRemoteLinkStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,14 +20,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class NewIssueRemoteLinkStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 3529709240318435576L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final Object remoteLink;
 
   @DataBoundConstructor
@@ -56,6 +58,7 @@ public class NewIssueRemoteLinkStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 325576266548671174L;
 
     private final NewIssueRemoteLinkStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -19,11 +21,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class NewIssueStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -3952881085849787165L;
 
-  @Getter
   private final IssueInput issue;
 
   @DataBoundConstructor
@@ -52,6 +55,7 @@ public class NewIssueStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 2782781910330634547L;
 
     private final NewIssueStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -20,11 +22,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class NewIssuesStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -1390437007976428509L;
 
-  @Getter
   private final IssuesInput issues;
 
   @DataBoundConstructor
@@ -53,6 +56,7 @@ public class NewIssuesStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = -7395311395671768027L;
 
     private final NewIssuesStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewVersionStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewVersionStep.java
@@ -2,6 +2,8 @@ package org.thoughtslive.jenkins.plugins.jira.steps;
 
 import hudson.Extension;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -16,11 +18,12 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class NewVersionStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -528328534268615694L;
 
-  @Getter
   private final Object version;
 
   @DataBoundConstructor
@@ -49,6 +52,7 @@ public class NewVersionStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 7109283776054289821L;
 
     private final NewVersionStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NotifyIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NotifyIssueStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,14 +20,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class NotifyIssueStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -5286750553487650184L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final Object notify;
 
   @DataBoundConstructor
@@ -55,6 +57,7 @@ public class NotifyIssueStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Void>> {
 
+    @Serial
     private static final long serialVersionUID = 2997765348391402484L;
 
     private final NotifyIssueStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/TransitionIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/TransitionIssueStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -18,14 +20,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class TransitionIssueStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 5648167982018270684L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final Object input;
 
   @DataBoundConstructor
@@ -56,6 +58,7 @@ public class TransitionIssueStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Void>> {
 
+    @Serial
     private static final long serialVersionUID = 6038231959460139190L;
 
     private final TransitionIssueStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/UploadAttachmentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/UploadAttachmentStep.java
@@ -6,6 +6,8 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -20,14 +22,14 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class UploadAttachmentStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = 2996407840986266627L;
 
-  @Getter
   private final String idOrKey;
 
-  @Getter
   private final String file;
 
   @DataBoundConstructor
@@ -57,6 +59,7 @@ public class UploadAttachmentStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 7064983919695548462L;
 
     private final UploadAttachmentStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/UserSearchStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/UserSearchStep.java
@@ -5,6 +5,8 @@ import static org.thoughtslive.jenkins.plugins.jira.util.Common.buildErrorRespon
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
+import java.io.Serial;
+
 import lombok.Getter;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -19,16 +21,15 @@ import org.thoughtslive.jenkins.plugins.jira.util.JiraStepExecution;
  *
  * @author Naresh Rayapati
  */
+@Getter
 public class UserSearchStep extends BasicJiraStep {
 
+  @Serial
   private static final long serialVersionUID = -7754102811625753132L;
 
-  @Getter
   private final String queryStr;
-  @Getter
   @DataBoundSetter
   private int startAt = 0;
-  @Getter
   @DataBoundSetter
   private int maxResults = 1000;
 
@@ -58,6 +59,7 @@ public class UserSearchStep extends BasicJiraStep {
 
   public static class Execution extends JiraStepExecution<ResponseData<Object>> {
 
+    @Serial
     private static final long serialVersionUID = 3640953129479843111L;
 
     private final UserSearchStep step;

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/util/JiraStepExecution.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/util/JiraStepExecution.java
@@ -16,6 +16,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.Serial;
 import java.util.Collections;
 import java.util.List;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -36,9 +37,10 @@ import org.thoughtslive.jenkins.plugins.jira.steps.BasicJiraStep;
  */
 public abstract class JiraStepExecution<T> extends SynchronousNonBlockingStepExecution<T> {
 
+  @Serial
   private static final long serialVersionUID = 3856797875872780808L;
 
-  public transient JiraService jiraService = null;
+  protected transient JiraService jiraService = null;
   protected transient PrintStream logger = null;
   protected transient String siteName = null;
   protected transient boolean failOnError = true;
@@ -63,11 +65,11 @@ public abstract class JiraStepExecution<T> extends SynchronousNonBlockingStepExe
    */
   protected static String prepareBuildUserId(List<Cause> causes) {
     String buildUser = "anonymous";
-    if (causes != null && causes.size() > 0) {
-      if (causes.get(0) instanceof UserIdCause) {
-        buildUser = ((UserIdCause) causes.get(0)).getUserId();
-      } else if (causes.get(0) instanceof UpstreamCause) {
-        List<Cause> upstreamCauses = ((UpstreamCause) causes.get(0)).getUpstreamCauses();
+    if (causes != null && !causes.isEmpty()) {
+      if (causes.get(0) instanceof UserIdCause userIdCause) {
+        buildUser = userIdCause.getUserId();
+      } else if (causes.get(0) instanceof UpstreamCause upstreamCause) {
+        List<Cause> upstreamCauses = upstreamCause.getUpstreamCauses();
         buildUser = prepareBuildUserId(upstreamCauses);
       }
     }
@@ -80,7 +82,6 @@ public abstract class JiraStepExecution<T> extends SynchronousNonBlockingStepExe
    * @return response if JIRA_SITE is empty or if there is no site configured with JIRA_SITE.
    * @throws AbortException when failOnError is true and JIRA_SITE is missing.
    */
-  @SuppressWarnings("hiding")
   protected <T> ResponseData<T> verifyCommon(final BasicJiraStep step) throws AbortException {
 
     logger = listener.getLogger();
@@ -133,7 +134,6 @@ public abstract class JiraStepExecution<T> extends SynchronousNonBlockingStepExe
    * @return same response back.
    * @throws AbortException if failOnError is true and response is not successful.
    */
-  @SuppressWarnings("hiding")
   protected <T> ResponseData<T> logResponse(ResponseData<T> response) throws AbortException {
 
     if (response.isSuccessful()) {
@@ -169,6 +169,5 @@ public abstract class JiraStepExecution<T> extends SynchronousNonBlockingStepExe
     return message + "\nAutomatically created by: " + buildUserId + " from " + buildUrl;
   }
 
-  @SuppressWarnings("hiding")
   protected abstract <T> ResponseData<T> verifyInput() throws Exception;
 }

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/AddCommentStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/AddCommentStepTest.java
@@ -40,9 +40,10 @@ public class AddCommentStepTest extends BaseTest {
     stepExecution = new AddCommentStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 
@@ -52,9 +53,10 @@ public class AddCommentStepTest extends BaseTest {
     stepExecution = new AddCommentStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("comment is empty.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("comment is empty.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/AddWatcherStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/AddWatcherStepTest.java
@@ -38,9 +38,10 @@ public class AddWatcherStepTest extends BaseTest {
     stepExecution = new AddWatcherStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 
@@ -50,9 +51,10 @@ public class AddWatcherStepTest extends BaseTest {
     stepExecution = new AddWatcherStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("userName is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("userName is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignIssueStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignIssueStepTest.java
@@ -38,9 +38,10 @@ public class AssignIssueStepTest extends BaseTest {
     stepExecution = new AssignIssueStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignableUserSearchStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignableUserSearchStepTest.java
@@ -41,9 +41,9 @@ public class AssignableUserSearchStepTest extends BaseTest {
     stepExecution = new AssignableUserSearchStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("either project or issueKey is required.")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("either project or issueKey is required.")
         .withStackTraceContaining("AbortException")
         .withNoCause();
   }

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteAttachmentStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteAttachmentStepTest.java
@@ -38,9 +38,11 @@ public class DeleteAttachmentStepTest extends BaseTest {
     stepExecution = new DeleteAttachmentStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test
@@ -49,9 +51,11 @@ public class DeleteAttachmentStepTest extends BaseTest {
     stepExecution = new DeleteAttachmentStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueLinkStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueLinkStepTest.java
@@ -38,9 +38,11 @@ public class DeleteIssueLinkStepTest extends BaseTest {
     stepExecution = new DeleteIssueLinkStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test
@@ -49,9 +51,11 @@ public class DeleteIssueLinkStepTest extends BaseTest {
     stepExecution = new DeleteIssueLinkStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinkStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinkStepTest.java
@@ -38,9 +38,10 @@ public class DeleteIssueRemoteLinkStepTest extends BaseTest {
     stepExecution = new DeleteIssueRemoteLinkStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 
@@ -50,9 +51,10 @@ public class DeleteIssueRemoteLinkStepTest extends BaseTest {
     stepExecution = new DeleteIssueRemoteLinkStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("linkId is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("linkId is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinksStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinksStepTest.java
@@ -38,9 +38,10 @@ public class DeleteIssueRemoteLinksStepTest extends BaseTest {
     stepExecution = new DeleteIssueRemoteLinksStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 
@@ -50,9 +51,10 @@ public class DeleteIssueRemoteLinksStepTest extends BaseTest {
     stepExecution = new DeleteIssueRemoteLinksStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/DownloadAttachmentStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/DownloadAttachmentStepTest.java
@@ -45,9 +45,11 @@ public class DownloadAttachmentStepTest extends BaseTest {
     final DownloadAttachmentStep step = new DownloadAttachmentStep("", "test.txt", true);
     stepExecution = new DownloadAttachmentStep.Execution(step, contextMock);
 
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is null or empty").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is null or empty")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test
@@ -55,9 +57,10 @@ public class DownloadAttachmentStepTest extends BaseTest {
     final DownloadAttachmentStep step = new DownloadAttachmentStep("100000", "", false);
     stepExecution = new DownloadAttachmentStep.Execution(step, contextMock);
 
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("file is null or empty").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("file is null or empty")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/EditCommentStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/EditCommentStepTest.java
@@ -42,9 +42,10 @@ public class EditCommentStepTest extends BaseTest {
     stepExecution = new EditCommentStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/EditIssueStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/EditIssueStepTest.java
@@ -49,9 +49,10 @@ public class EditIssueStepTest extends BaseTest {
     stepExecution = new EditIssueStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetAttachmentInfoStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetAttachmentInfoStepTest.java
@@ -38,9 +38,10 @@ public class GetAttachmentInfoStepTest extends BaseTest {
     stepExecution = new GetAttachmentInfoStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("id is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetCommentStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetCommentStepTest.java
@@ -38,9 +38,10 @@ public class GetCommentStepTest extends BaseTest {
     stepExecution = new GetCommentStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 
@@ -50,9 +51,10 @@ public class GetCommentStepTest extends BaseTest {
     stepExecution = new GetCommentStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("commentId is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("commentId is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetCommentsStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetCommentsStepTest.java
@@ -38,9 +38,10 @@ public class GetCommentsStepTest extends BaseTest {
     stepExecution = new GetCommentsStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetComponentIssueCountStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetComponentIssueCountStepTest.java
@@ -38,9 +38,11 @@ public class GetComponentIssueCountStepTest extends BaseTest {
     stepExecution = new GetComponentIssueCountStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test
@@ -49,9 +51,11 @@ public class GetComponentIssueCountStepTest extends BaseTest {
     stepExecution = new GetComponentIssueCountStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetComponentStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetComponentStepTest.java
@@ -38,9 +38,11 @@ public class GetComponentStepTest extends BaseTest {
     stepExecution = new GetComponentStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test
@@ -49,9 +51,11 @@ public class GetComponentStepTest extends BaseTest {
     stepExecution = new GetComponentStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueLinkStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueLinkStepTest.java
@@ -38,9 +38,11 @@ public class GetIssueLinkStepTest extends BaseTest {
     stepExecution = new GetIssueLinkStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test
@@ -49,9 +51,11 @@ public class GetIssueLinkStepTest extends BaseTest {
     stepExecution = new GetIssueLinkStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinkStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinkStepTest.java
@@ -38,9 +38,10 @@ public class GetIssueRemoteLinkStepTest extends BaseTest {
     stepExecution = new GetIssueRemoteLinkStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 
@@ -50,9 +51,10 @@ public class GetIssueRemoteLinkStepTest extends BaseTest {
     stepExecution = new GetIssueRemoteLinkStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("linkId is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("linkId is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinksStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinksStepTest.java
@@ -37,9 +37,10 @@ public class GetIssueRemoteLinksStepTest extends BaseTest {
     stepExecution = new GetIssueRemoteLinksStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 
@@ -49,9 +50,10 @@ public class GetIssueRemoteLinksStepTest extends BaseTest {
     stepExecution = new GetIssueRemoteLinksStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueStepTest.java
@@ -41,9 +41,10 @@ public class GetIssueStepTest extends BaseTest {
     stepExecution = new GetIssueStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueTransitionsStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueTransitionsStepTest.java
@@ -39,9 +39,10 @@ public class GetIssueTransitionsStepTest extends BaseTest {
     stepExecution = new GetIssueTransitionsStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueWatchesStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueWatchesStepTest.java
@@ -38,9 +38,10 @@ public class GetIssueWatchesStepTest extends BaseTest {
     stepExecution = new GetIssueWatchesStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectComponentsStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectComponentsStepTest.java
@@ -38,9 +38,10 @@ public class GetProjectComponentsStepTest extends BaseTest {
     stepExecution = new GetProjectComponentsStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectStatusesStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectStatusesStepTest.java
@@ -38,9 +38,10 @@ public class GetProjectStatusesStepTest extends BaseTest {
     stepExecution = new GetProjectStatusesStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectStepTest.java
@@ -38,9 +38,10 @@ public class GetProjectStepTest extends BaseTest {
     stepExecution = new GetProjectStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectVersionsStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectVersionsStepTest.java
@@ -38,9 +38,10 @@ public class GetProjectVersionsStepTest extends BaseTest {
     stepExecution = new GetProjectVersionsStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetVersionStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/GetVersionStepTest.java
@@ -38,9 +38,11 @@ public class GetVersionStepTest extends BaseTest {
     stepExecution = new GetVersionStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test
@@ -49,9 +51,11 @@ public class GetVersionStepTest extends BaseTest {
     stepExecution = new GetVersionStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-      stepExecution.run();
-    }).withMessage("id is empty or null.").withStackTraceContaining("AbortException").withNoCause();
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("id is empty or null.")
+        .withStackTraceContaining("AbortException")
+        .withNoCause();
   }
 
   @Test

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/JqlSearchStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/JqlSearchStepTest.java
@@ -40,9 +40,10 @@ public class JqlSearchStepTest extends BaseTest {
     stepExecution = new JqlSearchStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("jql is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("jql is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/LinkIssuesStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/LinkIssuesStepTest.java
@@ -39,9 +39,10 @@ public class LinkIssuesStepTest extends BaseTest {
     stepExecution = new LinkIssuesStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("type is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("type is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 
@@ -51,9 +52,10 @@ public class LinkIssuesStepTest extends BaseTest {
     stepExecution = new LinkIssuesStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("inwardKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("inwardKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 
@@ -63,9 +65,10 @@ public class LinkIssuesStepTest extends BaseTest {
     stepExecution = new LinkIssuesStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("outwardKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("outwardKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueRemoteLinkStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueRemoteLinkStepTest.java
@@ -39,9 +39,10 @@ public class NewIssueRemoteLinkStepTest extends BaseTest {
     stepExecution = new NewIssueRemoteLinkStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStepTest.java
@@ -31,7 +31,7 @@ public class NewIssueStepTest extends BaseTest {
   @Before
   public void setup() throws IOException, InterruptedException {
 
-    final Map<String, Object> fields = new HashMap<String, Object>();
+    final Map<String, Object> fields = new HashMap<>();
     fields.put("summary", "Summary");
     fields.put("description", null);
     fields.put("duedate", DateTime.now().toString());

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStepTest.java
@@ -35,8 +35,8 @@ public class NewIssuesStepTest extends BaseTest {
   public void setup() throws IOException, InterruptedException {
 
     // Prepare site.
-    final List<IssueInput> issues = new ArrayList<IssueInput>();
-    final Map<String, Object> fields = new HashMap<String, Object>();
+    final List<IssueInput> issues = new ArrayList<>();
+    final Map<String, Object> fields = new HashMap<>();
     fields.put("summary", "Summary");
     fields.put("description", null);
     fields.put("duedate", DateTime.now().toString());

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NotifyIssueStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/NotifyIssueStepTest.java
@@ -43,9 +43,10 @@ public class NotifyIssueStepTest extends BaseTest {
     stepExecution = new NotifyIssueStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("idOrKey is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("idOrKey is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/UploadAttachmentStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/UploadAttachmentStepTest.java
@@ -41,9 +41,10 @@ public class UploadAttachmentStepTest extends BaseTest {
     final UploadAttachmentStep step = new UploadAttachmentStep("", "test.txt");
     stepExecution = new UploadAttachmentStep.Execution(step, contextMock);
 
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("ID or key is null or empty").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("ID or key is null or empty")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 
@@ -52,9 +53,10 @@ public class UploadAttachmentStepTest extends BaseTest {
     final UploadAttachmentStep step = new UploadAttachmentStep("TEST-1", "");
     stepExecution = new UploadAttachmentStep.Execution(step, contextMock);
 
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("file is null or empty").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("file is null or empty")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/UserSearchStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/UserSearchStepTest.java
@@ -39,9 +39,10 @@ public class UserSearchStepTest extends BaseTest {
     stepExecution = new UserSearchStep.Execution(step, contextMock);
 
     // Execute and assert Test.
-    assertThatExceptionOfType(AbortException.class).isThrownBy(() -> {
-          stepExecution.run();
-        }).withMessage("queryStr is empty or null.").withStackTraceContaining("AbortException")
+    assertThatExceptionOfType(AbortException.class)
+        .isThrownBy(() -> stepExecution.run())
+        .withMessage("queryStr is empty or null.")
+        .withStackTraceContaining("AbortException")
         .withNoCause();
   }
 


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features
* Minor cleanup

### Testing done

`mvn clean verify`

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
