### PR TITLE
feat(java): Require Jenkins core 2.479.1 and Java 17.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 11]
+    [platform: 'linux', jdk: 21]
+    [platform: 'windows', jdk: 17]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.17.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>2.28.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
   <parent>
     <artifactId>plugin</artifactId>
     <groupId>org.jenkins-ci.plugins</groupId>
-    <version>4.54</version>
+    <version>5.7</version>
+    <relativePath/>
   </parent>
   <artifactId>jira-steps</artifactId>
   <version>${revision}.${changelist}</version>
@@ -16,9 +17,8 @@
   <properties>
     <revision>2.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <java.level>8</java.level>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.361</jenkins.baseline>
+    <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <assertj-core.version>3.27.3</assertj-core.version>
@@ -39,15 +39,6 @@
     <name>ThoughtsLive</name>
     <url>https://nrayapati.github.io/</url>
   </organization>
-
-  <developers>
-    <developer>
-      <id>nrayapati</id>
-      <name>Naresh Rayapati</name>
-      <organization>ThoughtsLive</organization>
-      <organizationUrl>https://nrayapati.github.io/</organizationUrl>
-    </developer>
-  </developers>
 
   <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
     <connection>scm:git:https://github.com/${gitHubRepo}</connection>
@@ -76,8 +67,18 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <scope>import</scope>
         <type>pom</type>
-        <version>1763.v092b_8980a_f5e</version>
+        <version>4136.vca_c3202a_7fd1</version>
       </dependency>
+<dependency>
+<artifactId>error_prone_annotations</artifactId>
+<groupId>com.google.errorprone</groupId>
+<version>2.28.0</version>
+</dependency>
+<dependency>
+<groupId>com.google.j2objc</groupId>
+<artifactId>j2objc-annotations</artifactId>
+<version>3.0.0</version>
+</dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -141,6 +142,7 @@
     <dependency>
       <artifactId>mockito-inline</artifactId>
       <groupId>org.mockito</groupId>
+      <version>5.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>plugin</artifactId>
     <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
     <version>5.7</version>
-    <relativePath/>
+    <relativePath />
   </parent>
   <artifactId>jira-steps</artifactId>
   <version>${revision}.${changelist}</version>
   <packaging>hpi</packaging>
   <name>JIRA Pipeline Steps</name>
-  <inceptionYear>2016</inceptionYear>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  <inceptionYear>2016</inceptionYear>
+  <organization>
+    <name>ThoughtsLive</name>
+    <url>https://nrayapati.github.io/</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+    <connection>scm:git:https://github.com/${gitHubRepo}</connection>
+    <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
+  </scm>
   <properties>
     <revision>2.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
@@ -28,24 +45,104 @@
     <signpost.oauth.version>2.1.1</signpost.oauth.version>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
-  <licenses>
-    <license>
-      <distribution>repo</distribution>
-      <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-  <organization>
-    <name>ThoughtsLive</name>
-    <url>https://nrayapati.github.io/</url>
-  </organization>
 
-  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
-    <connection>scm:git:https://github.com/${gitHubRepo}</connection>
-    <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
-    <tag>${scmTag}</tag>
-    <url>https://github.com/${gitHubRepo}</url>
-  </scm>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>4136.vca_c3202a_7fd1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>2.28.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.j2objc</groupId>
+        <artifactId>j2objc-annotations</artifactId>
+        <version>3.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+      <version>2.13.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client</artifactId>
+      <version>${google.oauth.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.retrofit2</groupId>
+      <artifactId>adapter-rxjava</artifactId>
+      <version>${retrofit2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.retrofit2</groupId>
+      <artifactId>converter-jackson</artifactId>
+      <version>${retrofit2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>oauth.signpost</groupId>
+      <artifactId>signpost-core</artifactId>
+      <version>${signpost.oauth.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>${lombok.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj-core.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>5.2.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <repositories>
     <repository>
@@ -59,104 +156,6 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <groupId>io.jenkins.tools.bom</groupId>
-        <scope>import</scope>
-        <type>pom</type>
-        <version>4136.vca_c3202a_7fd1</version>
-      </dependency>
-<dependency>
-<artifactId>error_prone_annotations</artifactId>
-<groupId>com.google.errorprone</groupId>
-<version>2.28.0</version>
-</dependency>
-<dependency>
-<groupId>com.google.j2objc</groupId>
-<artifactId>j2objc-annotations</artifactId>
-<version>3.0.0</version>
-</dependency>
-    </dependencies>
-  </dependencyManagement>
-
-  <dependencies>
-    <dependency>
-      <artifactId>workflow-step-api</artifactId>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>jackson2-api</artifactId>
-      <groupId>org.jenkins-ci.plugins</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>credentials</artifactId>
-      <groupId>org.jenkins-ci.plugins</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>script-security</artifactId>
-      <groupId>org.jenkins-ci.plugins</groupId>
-    </dependency>
-
-    <dependency>
-      <artifactId>jackson-datatype-joda</artifactId>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <version>2.13.3</version>
-    </dependency>
-    <dependency>
-      <artifactId>adapter-rxjava</artifactId>
-      <groupId>com.squareup.retrofit2</groupId>
-      <version>${retrofit2.version}</version>
-    </dependency>
-    <dependency>
-      <artifactId>converter-jackson</artifactId>
-      <groupId>com.squareup.retrofit2</groupId>
-      <version>${retrofit2.version}</version>
-    </dependency>
-    <dependency>
-      <artifactId>signpost-core</artifactId>
-      <groupId>oauth.signpost</groupId>
-      <version>${signpost.oauth.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.oauth-client</groupId>
-      <artifactId>google-oauth-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <artifactId>httpclient</artifactId>
-          <groupId>org.apache.httpcomponents</groupId>
-        </exclusion>
-      </exclusions>
-      <version>${google.oauth.version}</version>
-    </dependency>
-    <dependency>
-      <artifactId>lombok</artifactId>
-      <groupId>org.projectlombok</groupId>
-      <scope>provided</scope>
-      <version>${lombok.version}</version>
-    </dependency>
-
-    <!-- Test Dependencies -->
-    <dependency>
-      <artifactId>mockito-inline</artifactId>
-      <groupId>org.mockito</groupId>
-      <version>5.2.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <artifactId>junit</artifactId>
-      <groupId>junit</groupId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <artifactId>assertj-core</artifactId>
-      <groupId>org.assertj</groupId>
-      <version>${assertj-core.version}</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
 
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,17 @@
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>2.17.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
+        <version>2.17.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
         <version>2.17.0</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,15 @@
           <compatibleSinceVersion>1.5.0</compatibleSinceVersion>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>src/main/resources/spotbugs-exclude.xml</excludeFilterFile>
+          <xmlOutput>true</xmlOutput>
+          <outputDirectory>target</outputDirectory>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/JiraStepsConfig.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/JiraStepsConfig.java
@@ -15,7 +15,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Represents JIRA Global Configuration.
@@ -85,7 +85,7 @@ public class JiraStepsConfig extends AbstractDescribableImpl<JiraStepsConfig> {
     }
 
     @Override
-    public JiraStepsConfig newInstance(@Nonnull final StaplerRequest req, final JSONObject formData)
+    public JiraStepsConfig newInstance(@Nonnull final StaplerRequest2 req, final JSONObject formData)
         throws FormException {
       JiraStepsConfig jiraConfig = req.bindJSON(JiraStepsConfig.class, formData);
       if (jiraConfig.siteName == null) {
@@ -95,7 +95,7 @@ public class JiraStepsConfig extends AbstractDescribableImpl<JiraStepsConfig> {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject formData) {
+    public boolean configure(StaplerRequest2 req, JSONObject formData) {
       Stapler.CONVERT_UTILS.deregister(java.net.URL.class);
       Stapler.CONVERT_UTILS.register(new EmptyFriendlyURLConverter(), java.net.URL.class);
       sites.replaceBy(req.bindJSONToList(Site.class, formData.get("sites")));

--- a/src/main/resources/spotbugs-exclude.xml
+++ b/src/main/resources/spotbugs-exclude.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<FindBugsFilter>
+    <Match>
+        <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    </Match>
+</FindBugsFilter>


### PR DESCRIPTION
# Description

## Why Upgrade to Java 17 and Jenkins 2.479.x?

- **Embrace Java 17 LTS Stability:** Benefit from long-term support with modern language features that improve development practice and plugin performance.

- **Harness Jenkins 2.479.x Innovations:** Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.

- **Enhance Security:** Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.

- **Align with the Community:** Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.

- **Enjoy a Better Developer Experience:** Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.

## Removing `developers` Tag from `pom.xml`

Jenkins no longer requires the `developers` tag in `pom.xml`, as the `developers` section was traditionally used to list individuals responsible for the plugin.
Instead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.

### Benefits of Removing `developers` Tag:

- **Simplification:** Removes unnecessary metadata from the `pom.xml`, resulting in a cleaner and more maintainable file.
- **Consistency:** Centralizes developer information management through the RPU, minimizing discrepancies.
- **Security:** Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.

Removing the `developers` tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.

## The checks aren't checking, why is that?

The issue likely stems from your `Jenkinsfile`, which is still declaring Java 8 or 11.
The Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a `Jenkinsfile` supplied by a pull request.

To resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the "replay the build" feature in Jenkins.

Please let us know if you need any assistance with this process.

## Summary

By upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!


# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description.
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
