### PR TITLE
Feature/token

### DIFF
--- a/hugo/content/getting-started/config/authentication.md
+++ b/hugo/content/getting-started/config/authentication.md
@@ -9,7 +9,8 @@ lastmodifierdisplayname = "Naresh Rayapati"
 
 ## Authentication
 
-This plugin supports both Basic and OAuth, OAuth is preferred over the Basic authentication.
+This plugin supports Basic Authentication, OAuth, and Personal Access Tokens.
+OAuth is preferred over the Basic authentication.
 
 ### Basic Authentication
 
@@ -39,11 +40,11 @@ This plugin supports both Basic and OAuth, OAuth is preferred over the Basic aut
 
 {{% alert theme="info" %}} Please take note that above screenshot missing **ReadTimeout(ms)** {{% /alert %}}
 
-### Use Credential Plugin for basic authentication
+### Use Credential Plugin for Password or Personal Access Token Authentication
 
 * Goto **Manage Jenkins > Configure System > JIRA Steps > Add Site > Choose Credential**.
   * Name = Jira Site Name
   * URL = Jira Site URL
-  * Credentials = Choose a stored credential
+  * Credentials = Choose a stored credential (Username with password for password-based authentication, or Secret text for Personal Access Token)
 
 ![Credential](https://raw.githubusercontent.com/jenkinsci/jira-steps-plugin/master/hugo/static/images/jira_site_credential.png)

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,12 @@
       <version>${assertj-core.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>${okhttp3.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <assertj-core.version>3.27.3</assertj-core.version>
     <google.oauth.version>1.38.0</google.oauth.version>
     <lombok.version>1.18.36</lombok.version>
+    <okhttp3.version>4.12.0</okhttp3.version>
     <retrofit2.version>2.9.0</retrofit2.version>
     <signpost.oauth.version>2.1.1</signpost.oauth.version>
     <maven.javadoc.skip>true</maven.javadoc.skip>
@@ -78,6 +79,11 @@
         <type>pom</type>
         <version>1763.v092b_8980a_f5e</version>
       </dependency>
+      <dependency>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <version>1.9.25</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -113,6 +119,11 @@
       <artifactId>converter-jackson</artifactId>
       <groupId>com.squareup.retrofit2</groupId>
       <version>${retrofit2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${okhttp3.version}</version>
     </dependency>
     <dependency>
       <artifactId>signpost-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,10 @@
       <groupId>org.jenkins-ci.plugins</groupId>
     </dependency>
     <dependency>
+      <artifactId>plain-credentials</artifactId>
+      <groupId>org.jenkins-ci.plugins</groupId>
+    </dependency>
+    <dependency>
       <artifactId>script-security</artifactId>
       <groupId>org.jenkins-ci.plugins</groupId>
     </dependency>

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/Site.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/Site.java
@@ -3,9 +3,10 @@ package org.thoughtslive.jenkins.plugins.jira;
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
-import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
@@ -39,6 +40,7 @@ import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -222,9 +224,15 @@ public class Site extends AbstractDescribableImpl<Site> {
       }
 
       List<DomainRequirement> domainRequirements = URIRequirementBuilder.fromUri(url).build();
-      if (CredentialsProvider.listCredentials(StandardUsernameCredentials.class, item,
-              getAuthentication(item), domainRequirements, CredentialsMatchers.withId(credentialsId))
-          .isEmpty()) {
+      boolean credentialsIsUsernameCredentials = !CredentialsProvider.listCredentials(
+          StandardUsernameCredentials.class, item, getAuthentication(item), domainRequirements,
+          CredentialsMatchers.withId(credentialsId)
+      ).isEmpty();
+      boolean credentialsIsTokenCredentials = !CredentialsProvider.listCredentials(
+          StringCredentials.class, item, getAuthentication(item), domainRequirements,
+          CredentialsMatchers.withId(credentialsId)
+      ).isEmpty();
+      if (!credentialsIsUsernameCredentials && !credentialsIsTokenCredentials) {
         return FormValidation.error(Messages.Site_invalidCredentialsId());
       }
       return FormValidation.ok();
@@ -251,13 +259,16 @@ public class Site extends AbstractDescribableImpl<Site> {
       Authentication authentication = getAuthentication(item);
       List<DomainRequirement> domainRequirements = URIRequirementBuilder.fromUri(url).build();
       CredentialsMatcher always = CredentialsMatchers.always();
-      Class type = UsernamePasswordCredentials.class;
+      Class<? extends StandardCredentials> usernamePasswordType = StandardUsernamePasswordCredentials.class;
+      Class<? extends StandardCredentials> tokenType = StringCredentials.class;
 
       result.includeEmptyValue();
       if (item != null) {
-        result.includeMatchingAs(authentication, item, type, domainRequirements, always);
+        result.includeMatchingAs(authentication, item, usernamePasswordType, domainRequirements, always);
+        result.includeMatchingAs(authentication, item, tokenType, domainRequirements, always);
       } else {
-        result.includeMatchingAs(authentication, Jenkins.get(), type, domainRequirements, always);
+        result.includeMatchingAs(authentication, Jenkins.get(), usernamePasswordType, domainRequirements, always);
+        result.includeMatchingAs(authentication, Jenkins.get(), tokenType, domainRequirements, always);
       }
       return result;
     }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/RequestAdapter.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/login/RequestAdapter.java
@@ -5,7 +5,9 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import oauth.signpost.http.HttpRequest;
+import okhttp3.MediaType;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okio.Buffer;
 
 public class RequestAdapter implements HttpRequest {
@@ -27,9 +29,10 @@ public class RequestAdapter implements HttpRequest {
 
   @Override
   public String getContentType() {
-    if (request.body() != null) {
-      return (request.body().contentType() != null) ? request.body().contentType().toString()
-          : null;
+      RequestBody body = request.body();
+      if (body != null) {
+        MediaType contentType = body.contentType();
+        return (contentType != null) ? contentType.toString() : null;
     }
     return null;
   }
@@ -41,11 +44,12 @@ public class RequestAdapter implements HttpRequest {
 
   @Override
   public InputStream getMessagePayload() throws IOException {
-    if (request.body() == null) {
+      RequestBody body = request.body();
+      if (body == null) {
       return null;
     }
     Buffer buf = new Buffer();
-    request.body().writeTo(buf);
+    body.writeTo(buf);
     return buf.inputStream();
   }
 

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraService.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraService.java
@@ -62,8 +62,8 @@ public class JiraService {
         InetSocketAddress proxyAddr = new InetSocketAddress(proxyConfiguration.name,
             proxyConfiguration.port);
         Authenticator proxyAuthenticator = (route, response) -> {
-          String credential = Credentials.basic(proxyConfiguration.getUserName(),
-              proxyConfiguration.getPassword());
+          String proxyUserName = (proxyConfiguration.getUserName() != null ? proxyConfiguration.getUserName() : "");
+          String credential = Credentials.basic(proxyUserName, proxyConfiguration.getPassword());
           return response.request().newBuilder()
               .header("Proxy-Authorization", credential)
               .build();

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddCommentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddCommentStep.java
@@ -26,15 +26,15 @@ public class AddCommentStep extends BasicJiraStep {
   private static final long serialVersionUID = 8523118063993121080L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Deprecated
   @Getter
-  private final String comment;
+  public final String comment;
 
   @Getter
   @DataBoundSetter
-  private Object input;
+  public Object input;
 
   @Deprecated
   @DataBoundConstructor

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddWatcherStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AddWatcherStep.java
@@ -23,10 +23,10 @@ public class AddWatcherStep extends BasicJiraStep {
   private static final long serialVersionUID = 6417829072320454268L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final String userName;
+  public final String userName;
 
   @DataBoundConstructor
   public AddWatcherStep(final String idOrKey, final String userName) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignIssueStep.java
@@ -23,13 +23,13 @@ public class AssignIssueStep extends BasicJiraStep {
   private static final long serialVersionUID = -7552691123209663987L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final String userName;
+  public final String userName;
 
   @Getter
-  private final String accountId;
+  public final String accountId;
 
   @DataBoundConstructor
   public AssignIssueStep(final String idOrKey, final String userName, final String accountId) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignableUserSearchStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/AssignableUserSearchStep.java
@@ -24,19 +24,19 @@ public class AssignableUserSearchStep extends BasicJiraStep {
   private static final long serialVersionUID = -7754102811625753132L;
 
   @Getter
-  private String project;
+  public String project;
 
   @Getter
-  private String issueKey;
+  public String issueKey;
   @Getter
   @DataBoundSetter
-  private String queryStr;
+  public String queryStr;
   @Getter
   @DataBoundSetter
-  private int startAt = 0;
+  public int startAt = 0;
   @Getter
   @DataBoundSetter
-  private int maxResults = 1000;
+  public int maxResults = 1000;
 
   @DataBoundConstructor
   public AssignableUserSearchStep(final String project, final String issueKey) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/BasicJiraStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/BasicJiraStep.java
@@ -22,19 +22,19 @@ public abstract class BasicJiraStep extends Step implements Serializable {
 
   @Getter
   @DataBoundSetter
-  private String site;
+  public String site;
 
   @Getter
   @DataBoundSetter
-  private boolean failOnError = true;
+  public boolean failOnError = true;
 
   @Getter
   @DataBoundSetter
-  private boolean auditLog = true;
+  public boolean auditLog = true;
 
   @Getter
   @DataBoundSetter
-  private Map<String, String> queryParams = new HashMap<>();
+  public Map<String, String> queryParams = new HashMap<>();
 
   @Extension
   public static class JiraWhitelist extends ProxyWhitelist {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteAttachmentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteAttachmentStep.java
@@ -23,7 +23,7 @@ public class DeleteAttachmentStep extends BasicJiraStep {
   private static final long serialVersionUID = -4661648934764886451L;
 
   @Getter
-  private final String id;
+  public final String id;
 
   @DataBoundConstructor
   public DeleteAttachmentStep(final String id) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueLinkStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueLinkStep.java
@@ -22,7 +22,7 @@ public class DeleteIssueLinkStep extends BasicJiraStep {
 
   private static final long serialVersionUID = -4252560961571411897L;
   @Getter
-  private final String id;
+  public final String id;
 
   @DataBoundConstructor
   public DeleteIssueLinkStep(final String id) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinkStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinkStep.java
@@ -23,10 +23,10 @@ public class DeleteIssueRemoteLinkStep extends BasicJiraStep {
   private static final long serialVersionUID = 3529709240318435576L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final String linkId;
+  public final String linkId;
 
   @DataBoundConstructor
   public DeleteIssueRemoteLinkStep(final String idOrKey, final String linkId) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinksStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DeleteIssueRemoteLinksStep.java
@@ -23,10 +23,10 @@ public class DeleteIssueRemoteLinksStep extends BasicJiraStep {
   private static final long serialVersionUID = 3529709240318435576L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final String globalId;
+  public final String globalId;
 
   @DataBoundConstructor
   public DeleteIssueRemoteLinksStep(final String idOrKey, final String globalId) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DownloadAttachmentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/DownloadAttachmentStep.java
@@ -27,13 +27,13 @@ public class DownloadAttachmentStep extends BasicJiraStep {
   private static final long serialVersionUID = 6317067114642701582L;
 
   @Getter
-  private final String id;
+  public final String id;
 
   @Getter
-  private final String file;
+  public final String file;
 
   @Getter
-  private boolean override;
+  public boolean override;
 
   @DataBoundConstructor
   public DownloadAttachmentStep(final String id, final String file,

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditCommentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditCommentStep.java
@@ -26,18 +26,18 @@ public class EditCommentStep extends BasicJiraStep {
   private static final long serialVersionUID = -6330276534463853856L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final String commentId;
+  public final String commentId;
 
   @Deprecated
   @Getter
-  private final String comment;
+  public final String comment;
 
   @Getter
   @DataBoundSetter
-  private Object input;
+  public Object input;
 
   @Deprecated
   @DataBoundConstructor

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditComponentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditComponentStep.java
@@ -23,10 +23,10 @@ public class EditComponentStep extends BasicJiraStep {
   private static final long serialVersionUID = 6528605492208170984L;
 
   @Getter
-  private final String id;
+  public final String id;
 
   @Getter
-  private final Object component;
+  public final Object component;
 
   @DataBoundConstructor
   public EditComponentStep(final String id, final Object component) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditIssueStep.java
@@ -23,10 +23,10 @@ public class EditIssueStep extends BasicJiraStep {
   private static final long serialVersionUID = -4542562652787306504L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final Object issue;
+  public final Object issue;
 
   @DataBoundConstructor
   public EditIssueStep(final String idOrKey, final Object issue) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditVersionStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/EditVersionStep.java
@@ -22,10 +22,10 @@ public class EditVersionStep extends BasicJiraStep {
   private static final long serialVersionUID = -2029161404995143511L;
 
   @Getter
-  private final String id;
+  public final String id;
 
   @Getter
-  private final Object version;
+  public final Object version;
 
   @DataBoundConstructor
   public EditVersionStep(final String id, final Object version) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetAttachmentInfoStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetAttachmentInfoStep.java
@@ -23,7 +23,7 @@ public class GetAttachmentInfoStep extends BasicJiraStep {
   private static final long serialVersionUID = -5058732591554743625L;
 
   @Getter
-  private final String id;
+  public final String id;
 
   @DataBoundConstructor
   public GetAttachmentInfoStep(final String id) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetCommentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetCommentStep.java
@@ -23,10 +23,10 @@ public class GetCommentStep extends BasicJiraStep {
   private static final long serialVersionUID = -3225315653270733874L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final String commentId;
+  public final String commentId;
 
   @DataBoundConstructor
   public GetCommentStep(final String idOrKey, final String commentId) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetCommentsStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetCommentsStep.java
@@ -23,7 +23,7 @@ public class GetCommentsStep extends BasicJiraStep {
   private static final long serialVersionUID = 3545679919575498803L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @DataBoundConstructor
   public GetCommentsStep(final String idOrKey) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetComponentIssueCountStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetComponentIssueCountStep.java
@@ -23,7 +23,7 @@ public class GetComponentIssueCountStep extends BasicJiraStep {
   private static final long serialVersionUID = -4668092703770930031L;
 
   @Getter
-  private final String id;
+  public final String id;
 
   @DataBoundConstructor
   public GetComponentIssueCountStep(final String id) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetComponentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetComponentStep.java
@@ -23,7 +23,7 @@ public class GetComponentStep extends BasicJiraStep {
   private static final long serialVersionUID = 387862257528432812L;
 
   @Getter
-  private final String id;
+  public final String id;
 
   @DataBoundConstructor
   public GetComponentStep(final String id) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueLinkStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueLinkStep.java
@@ -22,7 +22,7 @@ public class GetIssueLinkStep extends BasicJiraStep {
 
   private static final long serialVersionUID = -4252560961571411897L;
   @Getter
-  private final String id;
+  public final String id;
 
   @DataBoundConstructor
   public GetIssueLinkStep(final String id) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinkStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinkStep.java
@@ -23,10 +23,10 @@ public class GetIssueRemoteLinkStep extends BasicJiraStep {
   private static final long serialVersionUID = 3529709240318435576L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final String linkId;
+  public final String linkId;
 
   @DataBoundConstructor
   public GetIssueRemoteLinkStep(final String idOrKey, final String linkId) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinksStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueRemoteLinksStep.java
@@ -23,10 +23,10 @@ public class GetIssueRemoteLinksStep extends BasicJiraStep {
   private static final long serialVersionUID = 3529709240318435576L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final String globalId;
+  public final String globalId;
 
   @DataBoundConstructor
   public GetIssueRemoteLinksStep(final String idOrKey, final String globalId) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueStep.java
@@ -23,7 +23,7 @@ public class GetIssueStep extends BasicJiraStep {
   private static final long serialVersionUID = -8758698444697767020L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @DataBoundConstructor
   public GetIssueStep(final String idOrKey) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueTransitionsStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueTransitionsStep.java
@@ -23,7 +23,7 @@ public class GetIssueTransitionsStep extends BasicJiraStep {
   private static final long serialVersionUID = 76788852720885769L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @DataBoundConstructor
   public GetIssueTransitionsStep(final String idOrKey) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueWatchesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetIssueWatchesStep.java
@@ -23,7 +23,7 @@ public class GetIssueWatchesStep extends BasicJiraStep {
   private static final long serialVersionUID = -4095433082021536972L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @DataBoundConstructor
   public GetIssueWatchesStep(final String idOrKey) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectComponentsStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectComponentsStep.java
@@ -23,7 +23,7 @@ public class GetProjectComponentsStep extends BasicJiraStep {
   private static final long serialVersionUID = 1831738736953963099L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @DataBoundConstructor
   public GetProjectComponentsStep(final String idOrKey) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectStatusesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectStatusesStep.java
@@ -23,7 +23,7 @@ public class GetProjectStatusesStep extends BasicJiraStep {
   private static final long serialVersionUID = -402279833026508134L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @DataBoundConstructor
   public GetProjectStatusesStep(final String idOrKey) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectStep.java
@@ -23,7 +23,7 @@ public class GetProjectStep extends BasicJiraStep {
   private static final long serialVersionUID = 8326344234130259321L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @DataBoundConstructor
   public GetProjectStep(final String idOrKey) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectVersionsStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetProjectVersionsStep.java
@@ -23,7 +23,7 @@ public class GetProjectVersionsStep extends BasicJiraStep {
   private static final long serialVersionUID = 3692152135588867038L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @DataBoundConstructor
   public GetProjectVersionsStep(final String idOrKey) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetVersionStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/GetVersionStep.java
@@ -22,7 +22,7 @@ public class GetVersionStep extends BasicJiraStep {
 
   private static final long serialVersionUID = -4252560961571411897L;
   @Getter
-  private final String id;
+  public final String id;
 
   @DataBoundConstructor
   public GetVersionStep(final String id) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/JqlSearchStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/JqlSearchStep.java
@@ -24,19 +24,19 @@ public class JqlSearchStep extends BasicJiraStep {
   private static final long serialVersionUID = -7754102811625753132L;
 
   @Getter
-  private final String jql;
+  public final String jql;
 
   @Getter
   @DataBoundSetter
-  private int startAt = 0;
+  public int startAt = 0;
 
   @Getter
   @DataBoundSetter
-  private int maxResults = 1000;
+  public int maxResults = 1000;
 
   @Getter
   @DataBoundSetter
-  private Object fields;
+  public Object fields;
 
   @DataBoundConstructor
   public JqlSearchStep(final String jql) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/LinkIssuesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/LinkIssuesStep.java
@@ -24,17 +24,17 @@ public class LinkIssuesStep extends BasicJiraStep {
   private static final long serialVersionUID = -1881920733234295481L;
 
   @Getter
-  private final String type;
+  public final String type;
 
   @Getter
-  private final String inwardKey;
+  public final String inwardKey;
 
   @Getter
-  private final String outwardKey;
+  public final String outwardKey;
   // Comment is optional.
   @Getter
   @DataBoundSetter
-  private String comment;
+  public String comment;
 
   @DataBoundConstructor
   public LinkIssuesStep(final String type, final String inwardKey, final String outwardKey) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewComponentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewComponentStep.java
@@ -21,7 +21,7 @@ public class NewComponentStep extends BasicJiraStep {
   private static final long serialVersionUID = 4939494003115851145L;
 
   @Getter
-  private final Object component;
+  public final Object component;
 
   @DataBoundConstructor
   public NewComponentStep(final Object component) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueRemoteLinkStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueRemoteLinkStep.java
@@ -23,10 +23,10 @@ public class NewIssueRemoteLinkStep extends BasicJiraStep {
   private static final long serialVersionUID = 3529709240318435576L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final Object remoteLink;
+  public final Object remoteLink;
 
   @DataBoundConstructor
   public NewIssueRemoteLinkStep(final String idOrKey, final Object remoteLink) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssueStep.java
@@ -24,7 +24,7 @@ public class NewIssueStep extends BasicJiraStep {
   private static final long serialVersionUID = -3952881085849787165L;
 
   @Getter
-  private final IssueInput issue;
+  public final IssueInput issue;
 
   @DataBoundConstructor
   public NewIssueStep(final IssueInput issue) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewIssuesStep.java
@@ -25,7 +25,7 @@ public class NewIssuesStep extends BasicJiraStep {
   private static final long serialVersionUID = -1390437007976428509L;
 
   @Getter
-  private final IssuesInput issues;
+  public final IssuesInput issues;
 
   @DataBoundConstructor
   public NewIssuesStep(final IssuesInput issues) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewVersionStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewVersionStep.java
@@ -21,7 +21,7 @@ public class NewVersionStep extends BasicJiraStep {
   private static final long serialVersionUID = -528328534268615694L;
 
   @Getter
-  private final Object version;
+  public final Object version;
 
   @DataBoundConstructor
   public NewVersionStep(final Object version) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NotifyIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NotifyIssueStep.java
@@ -23,10 +23,10 @@ public class NotifyIssueStep extends BasicJiraStep {
   private static final long serialVersionUID = -5286750553487650184L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final Object notify;
+  public final Object notify;
 
   @DataBoundConstructor
   public NotifyIssueStep(final String idOrKey, final Object notify) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/TransitionIssueStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/TransitionIssueStep.java
@@ -23,10 +23,10 @@ public class TransitionIssueStep extends BasicJiraStep {
   private static final long serialVersionUID = 5648167982018270684L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final Object input;
+  public final Object input;
 
   @DataBoundConstructor
   public TransitionIssueStep(final String idOrKey, final Object input) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/UploadAttachmentStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/UploadAttachmentStep.java
@@ -25,10 +25,10 @@ public class UploadAttachmentStep extends BasicJiraStep {
   private static final long serialVersionUID = 2996407840986266627L;
 
   @Getter
-  private final String idOrKey;
+  public final String idOrKey;
 
   @Getter
-  private final String file;
+  public final String file;
 
   @DataBoundConstructor
   public UploadAttachmentStep(final String idOrKey, final String file) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/UserSearchStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/UserSearchStep.java
@@ -24,13 +24,13 @@ public class UserSearchStep extends BasicJiraStep {
   private static final long serialVersionUID = -7754102811625753132L;
 
   @Getter
-  private final String queryStr;
+  public final String queryStr;
   @Getter
   @DataBoundSetter
-  private int startAt = 0;
+  public int startAt = 0;
   @Getter
   @DataBoundSetter
-  private int maxResults = 1000;
+  public int maxResults = 1000;
 
   @DataBoundConstructor
   public UserSearchStep(final String queryStr) {

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/util/JiraStepExecution.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/util/JiraStepExecution.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Collections;
 import java.util.List;
+
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.thoughtslive.jenkins.plugins.jira.Messages;
@@ -106,10 +108,13 @@ public abstract class JiraStepExecution<T> extends SynchronousNonBlockingStepExe
       if (jiraService == null) {
         if (LoginType.CREDENTIAL.name().equals(site.getLoginType())) {
           // at build time use of credentials must be checked against the user who run the build, see https://plugins.jenkins.io/authorize-project
-          StandardUsernameCredentials credentialsId = CredentialsProvider.findCredentialById(
+          StandardUsernameCredentials usernameCredentials = CredentialsProvider.findCredentialById(
               site.getCredentialsId(), StandardUsernameCredentials.class, run,
               Collections.emptyList());
-          if (credentialsId == null) {
+          StringCredentials tokenCredentials = CredentialsProvider.findCredentialById(
+              site.getCredentialsId(), StringCredentials.class, run,
+              Collections.emptyList());
+          if (usernameCredentials == null && tokenCredentials == null) {
             throw new AbortException(Messages.Site_invalidCredentialsId());
           }
         }

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/login/SingningInterceptorTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/login/SingningInterceptorTest.java
@@ -1,0 +1,105 @@
+package org.thoughtslive.jenkins.plugins.jira.login;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.thoughtslive.jenkins.plugins.jira.Site;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+
+import hudson.util.Secret;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+public class SingningInterceptorTest {
+    @ClassRule
+    public static JenkinsRule jenkins = new JenkinsRule();
+    @Rule
+    public TestName testName = new TestName();
+
+    @NotNull
+    private static OkHttpClient buildClient(Site jiraSite) {
+        return new OkHttpClient.Builder()
+            .addInterceptor(new SigningInterceptor(jiraSite)).build();
+    }
+
+    private static void addCredentials(Credentials credentials) throws IOException {
+        Iterable<CredentialsStore> credentialsStores = CredentialsProvider.lookupStores(jenkins.jenkins);
+        assumeThat(credentialsStores).hasSize(1);
+        CredentialsStore store = credentialsStores.iterator().next();
+        List<Domain> domains = store.getDomains();
+        assumeThat(domains).isNotEmpty();
+        store.addCredentials(domains.get(0), credentials);
+    }
+
+    private static MockWebServer mockWebServer() throws IOException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse());
+        server.start();
+        return server;
+    }
+
+    @Test
+    public void shouldUseBasicAuthWithUsernameAndPasswordDirectlyFromConfigWhenConfiguredTo()
+        throws IOException, InterruptedException {
+        Site jiraSite = mock(Site.class);
+        when(jiraSite.getLoginType()).thenReturn(Site.LoginType.BASIC.name());
+        when(jiraSite.getUserName()).thenReturn("scott");
+        when(jiraSite.getPassword()).thenReturn(Secret.fromString("tiger"));
+
+        OkHttpClient client = buildClient(jiraSite);
+
+        final RecordedRequest request;
+        try (MockWebServer server = mockWebServer()) {
+            client.newCall(new Request.Builder().url(server.url("/")).build()).execute().close();
+            request = server.takeRequest();
+        }
+        assertThat(request.getHeader("authorization"))
+            .isEqualTo("Basic " + Base64.getEncoder().encodeToString("scott:tiger".getBytes()));
+    }
+
+    @Test
+    public void shouldUseBasicAuthWithUsernameAndPasswordFromCredentialsWhenConfiguredTo()
+        throws IOException, InterruptedException {
+        String credentialsId = testName.getMethodName();
+        Site jiraSite = mock(Site.class);
+        when(jiraSite.getLoginType()).thenReturn(Site.LoginType.CREDENTIAL.name());
+        when(jiraSite.getCredentialsId()).thenReturn(credentialsId);
+
+        addCredentials(
+            new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, credentialsId, "Test credentials", "scott", "tiger"
+            )
+        );
+
+        OkHttpClient client = buildClient(jiraSite);
+
+        final RecordedRequest request;
+        try (MockWebServer server = mockWebServer()) {
+            client.newCall(new Request.Builder().url(server.url("/")).build()).execute().close();
+            request = server.takeRequest();
+        }
+        assertThat(request.getHeader("authorization"))
+            .isEqualTo("Basic " + Base64.getEncoder().encodeToString("scott:tiger".getBytes()));
+    }
+}

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/service/JiraServiceTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/service/JiraServiceTest.java
@@ -1,0 +1,190 @@
+package org.thoughtslive.jenkins.plugins.jira.service;
+
+import static java.net.http.HttpResponse.BodyHandlers.ofByteArray;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.thoughtslive.jenkins.plugins.jira.Site;
+import org.thoughtslive.jenkins.plugins.jira.api.ResponseData;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hudson.ProxyConfiguration;
+import junit.framework.TestCase;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okio.Buffer;
+
+public class JiraServiceTest {
+    public static MockWebServer jira;
+    public static MockWebServer proxy;
+    @ClassRule
+    public static JenkinsRule jenkins = new JenkinsRule();
+
+    @BeforeClass
+    public static void setUpJiraMock() throws IOException {
+        jira = new MockWebServer();
+        jira.setDispatcher(new Dispatcher() {
+            @NotNull
+            @Override
+            public MockResponse dispatch(@NotNull RecordedRequest recordedRequest) throws InterruptedException {
+                if (recordedRequest.getMethod().equals("GET")) {
+                    switch (recordedRequest.getPath()) {
+                    case "/rest/api/2/serverInfo": {
+                        try {
+                            return new MockResponse().setResponseCode(200)
+                                .setBody(new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(
+                                    Map.of(
+                                        "baseUrl", "https://jira",
+                                        "version", "9.12.7",
+                                        "versionNumbers", List.of(9, 12, 7),
+                                        "deploymentType", "Server",
+                                        "buildNumber", 9120007,
+                                        "buildDate", "2024-04-11T00:00:00.000+0200",
+                                        "databaseBuildNumber", 9120007,
+                                        "scmInfo", "77878f28c5a5673469d81b7d9f14744ca4b2ad1e",
+                                        "serverTitle", "Test JIRA"
+                                    )
+                                ));
+                        } catch (JsonProcessingException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                    }
+                }
+                TestCase.fail("Unrecognized request: " + recordedRequest.getMethod() + " " + recordedRequest.getPath());
+                return new MockResponse().setResponseCode(404);
+            }
+        });
+        jira.start();
+    }
+
+    @AfterClass
+    public static void stopJiraMock() throws IOException {
+        jira.shutdown();
+    }
+
+    @BeforeClass
+    public static void setUpProxy() throws IOException {
+        proxy = new MockWebServer();
+        proxy.setDispatcher(new Dispatcher() {
+            final Pattern REQUEST_LINE = Pattern.compile("(?<method>[^ ]+) +(?<resource>[^ ]+) +(?<extra>.*)");
+            @NotNull
+            @Override
+            public MockResponse dispatch(@NotNull RecordedRequest recordedRequest) throws InterruptedException {
+                if (recordedRequest.getHeader("Proxy-Authorization") == null) {
+                    return new MockResponse().setResponseCode(407).addHeader("Proxy-Authenticate", "Basic realm=test");
+                }
+                final Matcher matcher = REQUEST_LINE.matcher(recordedRequest.getRequestLine());
+                if (!matcher.matches()) {
+                    TestCase.fail("Invalid request: " + recordedRequest.getRequestLine());
+                    return new MockResponse().setResponseCode(500);
+                }
+                String method = matcher.group("method");
+                String resource = matcher.group("resource");
+                if (!resource.startsWith(jira.url("/").toString())) {
+                    TestCase.fail("Not a proxy request for the Jira mock: " + recordedRequest.getRequestLine());
+                    return new MockResponse().setResponseCode(500);
+                }
+                URI uri = URI.create(resource);
+                final HttpClient client = HttpClient.newBuilder().build();
+                try {
+                    final byte[] body = recordedRequest.getBody().readByteArray();
+                    final HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                        .method(method, HttpRequest.BodyPublishers.ofByteArray(body));
+                    recordedRequest.getHeaders()
+                        .toMultimap()
+                        .entrySet()
+                        .stream()
+                        .filter(e -> !(List.of("connection", "proxy-authorization", "host").contains(e.getKey().toLowerCase())))
+                        .forEach(e -> e.getValue().forEach(value -> requestBuilder.setHeader(e.getKey(), value)));
+                    requestBuilder.uri(uri);
+                    final HttpResponse<byte[]> response = client.send(requestBuilder.build(), ofByteArray());
+                    try (final Buffer output = new Buffer()) {
+                        output.write(response.body());
+                        return new MockResponse().setResponseCode(response.statusCode()).setBody(output);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        proxy.start();
+    }
+
+    @AfterClass
+    public static void stopProxy() throws IOException {
+        proxy.shutdown();
+    }
+
+    @After
+    public void clearProxyConfig() {
+        jenkins.getInstance().setProxy(null);
+    }
+
+    @Test
+    public void shouldCheckInfo() {
+        Site site = new Site(
+            "test", jira.url("/").url(), Site.LoginType.BASIC.name(), (int) Duration.ofMinutes(5).toMillis()
+        );
+        site.setUserName("scott");
+        site.setPassword("tiger");
+        JiraService service = new JiraService(site);
+        final ResponseData<Map<String, Object>> serverInfo = service.getServerInfo();
+        assertThat(serverInfo.isSuccessful()).isTrue();
+        assertThat(serverInfo.getMessage()).isNotNull();
+    }
+
+    @Test
+    public void shouldUseProxyAuthentication() throws InterruptedException {
+        Site site = new Site(
+            "test", jira.url("/").url(), Site.LoginType.BASIC.name(), (int) Duration.ofMinutes(5).toMillis()
+        );
+        site.setUserName("scott");
+        site.setPassword("tiger");
+        jenkins.getInstance().setProxy(new ProxyConfiguration("localhost", proxy.getPort(), "proxyuser", null));
+
+        JiraService service = new JiraService(site);
+        final ResponseData<Map<String, Object>> serverInfo = service.getServerInfo();
+        assertThat(serverInfo.getCode()).isNotEqualTo(-1);
+        assertThat(serverInfo.isSuccessful()).isTrue();
+        RecordedRequest request = jira.takeRequest();
+        assertThat(request.getMethod()).isEqualTo("GET");
+        assertThat(request.getPath()).isEqualTo("/rest/api/2/serverInfo");
+    }
+
+    @Test
+    public void shouldTolerateUseProxyAuthenticationHavingNullUsername() {
+        Site site = new Site(
+            "test", jira.url("/").url(), Site.LoginType.BASIC.name(), (int) Duration.ofMinutes(5).toMillis()
+        );
+        site.setUserName("scott");
+        site.setPassword("tiger");
+        jenkins.getInstance().setProxy(new ProxyConfiguration("localhost", proxy.getPort(), null, null));
+
+        JiraService service = new JiraService(site);
+        final ResponseData<Map<String, Object>> serverInfo = service.getServerInfo();
+        assertThat(serverInfo.getCode()).isNotEqualTo(-1);
+        assertThat(serverInfo.isSuccessful()).isTrue();
+    }
+}


### PR DESCRIPTION
# Description

This is a rebase of https://github.com/jenkinsci/jira-steps-plugin/pull/187 , which was closed due to inactivity.
See [JENKINS-66449](https://issues.jenkins-ci.org/browse/JENKINS-66449).

This change lets users pick StringCredentials in addition to UsernamePasswordCredentials in the credentials drop-down in the settings. This makes the SigningInterceptor send the secret of the credential as a bearer token, instead of using username and password for Basic Authentication. See https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html for the documentation on the Jira side.

There are automated tests in SingningInterceptorTest.

This can be tested manually by adding a Personal Access Token on a Jira instance, and add that as a String Credential in Jenkins. Then add a new site in the settings of jira-steps-plugin for that Jira instance, and choose Credentials as login type, and pick the new credential in the drop-down. Verify that a pipeline can run Jira steps using the new site.

# Submitter checklist
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description.
- [X] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [X] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
