### PR TITLE
Upgrade to oldest Jenkins still recommended

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     <changelist>999999-SNAPSHOT</changelist>
     <java.level>8</java.level>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.361</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.baseline>2.426</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <assertj-core.version>3.27.3</assertj-core.version>
     <google.oauth.version>1.38.0</google.oauth.version>
@@ -76,7 +76,7 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <scope>import</scope>
         <type>pom</type>
-        <version>1763.v092b_8980a_f5e</version>
+        <version>3208.vb_21177d4b_cd9</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
The Jenkins documentation states that one should not use versions no longer supportrted by the update center, and that the oldest LTS that is, is 2.426.3. Therefore, it´s probably a good idea to upgrade to that.

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description.
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
