### PR TITLE
Replace mockito-inline with mockito-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
 
     <!-- Test Dependencies -->
     <dependency>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <groupId>org.mockito</groupId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
## Replace `mockito-inline` with `mockito-core`

In version 5.x mockito switched their default mockmaker to `mockito-inline` ([source](https://github.com/mockito/mockito/releases/tag/v5.0.0)).
The corresponding artifact became obsolete and can be replaced with `mockito-core`

This PR replaces / removes the artifact and switches on `mockito-core` and the version provided by the `bom` instead.

### Testing done

None. Rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue