### PR TITLE
Resolved mismatch stubbings in AddCommentStepTest.java

### DIFF
--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/BaseTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/BaseTest.java
@@ -64,4 +64,8 @@ public class BaseTest {
     site.close();
     closeable.close();
   }
+
+  public EnvVars getEnvVars() {
+    return envVarsMock;
+  }
 }

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/AddCommentStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/AddCommentStepTest.java
@@ -35,7 +35,7 @@ public class AddCommentStepTest extends BaseTest {
 
   @Test
   public void testDeprecatedWithEmptyIdOrKeyThrowsAbortException() throws Exception {
-
+    when(getEnvVars().get("JIRA_FAIL_ON_ERROR")).thenReturn(null);
     final AddCommentStep step = new AddCommentStep("", "test comment");
     stepExecution = new AddCommentStep.Execution(step, contextMock);
 
@@ -48,6 +48,7 @@ public class AddCommentStepTest extends BaseTest {
 
   @Test
   public void testDeprecatedWithEmptyCommentThrowsAbortException() throws Exception {
+    when(getEnvVars().get("JIRA_FAIL_ON_ERROR")).thenReturn(null);
     final AddCommentStep step = new AddCommentStep("TEST-1", "");
     stepExecution = new AddCommentStep.Execution(step, contextMock);
 
@@ -60,6 +61,7 @@ public class AddCommentStepTest extends BaseTest {
 
   @Test
   public void testDeprecatedSuccessfulAddComment() throws Exception {
+    when(getEnvVars().get("JIRA_FAIL_ON_ERROR")).thenReturn(null);
     final AddCommentStep step = new AddCommentStep("TEST-1", "test comment");
     stepExecution = new AddCommentStep.Execution(step, contextMock);
 


### PR DESCRIPTION
# Description

I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In tests `testDeprecatedWithEmptyIdOrKeyThrowsAbortException`, `testDeprecatedWithEmptyCommentThrowsAbortException`,  and `testDeprecatedSuccessfulAddComment `: 

* the `envVarsMock` object:
i) is created in `BaseTest`
ii) during test execution the object calls `get` method with arguments `"svn.global_excluded_revprop"`, but does not stub this method invocation, resulting in mismatch stubbings. 

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback. I also found additional mismatch stubbings in other tests and am willing to submit more pull requests if you'd like.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate. (Not applicable)
- [x] Change is code complete and matches issue description.
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests. (Not applicable)
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.