### PR TITLE
Fix JQL search for Jira Cloud

### DIFF
--- a/hugo/content/getting-started/config/casc.md
+++ b/hugo/content/getting-started/config/casc.md
@@ -22,6 +22,7 @@ unclassified:
       loginType: 'BASIC'
       userName: 'foo'
       password: 'some pass'
+      useV3Search: true
     - name: 'moar jira'
       url: 'http://example.com'
       timeout: 10000
@@ -31,4 +32,5 @@ unclassified:
       privateKey: 'my private key'
       secret: 'super secret'
       token: 'my token'
+      useV3Search: false
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <inceptionYear>2016</inceptionYear>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <properties>
-    <revision>2.0</revision>
+    <revision>2.1</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <java.level>8</java.level>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/Site.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/Site.java
@@ -65,6 +65,8 @@ public class Site extends AbstractDescribableImpl<Site> {
   private int timeout;
   @Getter
   private int readTimeout;
+  @Getter
+  private boolean useV3Search;
   // Basic
   @Getter
   @Setter(onMethod = @__({@DataBoundSetter}))
@@ -90,11 +92,12 @@ public class Site extends AbstractDescribableImpl<Site> {
   private transient JiraService jiraService = null;
 
   @DataBoundConstructor
-  public Site(final String name, final URL url, final String loginType, final int timeout) {
+  public Site(final String name, final URL url, final String loginType, final int timeout, final boolean useV3Search) {
     this.name = Util.fixEmpty(name);
     this.url = url;
     this.loginType = Util.fixEmpty(loginType);
     this.timeout = timeout;
+    this.useV3Search = useV3Search;
   }
 
   public static Site get(final String siteName) {
@@ -125,6 +128,9 @@ public class Site extends AbstractDescribableImpl<Site> {
   public void setReadTimeout(final int readTimeout) {
     this.readTimeout = readTimeout;
   }
+
+  @DataBoundSetter
+  public void setUseV3Search(final boolean useV3Search) { this.useV3Search = useV3Search; }
 
   @DataBoundSetter
   public void setToken(final String token) {
@@ -270,7 +276,8 @@ public class Site extends AbstractDescribableImpl<Site> {
     public FormValidation doValidateCredentials(@QueryParameter String url,
         @QueryParameter String credentialsId,
         @QueryParameter Integer timeout,
-        @QueryParameter Integer readTimeout) throws IOException {
+        @QueryParameter Integer readTimeout,
+        @QueryParameter Boolean useV3Search) throws IOException {
       if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
         return FormValidation.warning("Insufficient permissions");
       }
@@ -290,7 +297,7 @@ public class Site extends AbstractDescribableImpl<Site> {
         return validation;
       }
 
-      Site site = new Site("test", new URL(url), LoginType.CREDENTIAL.name(), timeout);
+      Site site = new Site("test", new URL(url), LoginType.CREDENTIAL.name(), timeout, useV3Search);
       site.setCredentialsId(credentialsId);
       site.setReadTimeout(readTimeout);
 
@@ -318,6 +325,7 @@ public class Site extends AbstractDescribableImpl<Site> {
     public FormValidation doValidateBasic(@QueryParameter String name, @QueryParameter String url,
         @QueryParameter String loginType, @QueryParameter String timeout,
         @QueryParameter String readTimeout,
+        @QueryParameter Boolean useV3Search,
         @QueryParameter String userName, @QueryParameter String password,
         @QueryParameter String consumerKey, @QueryParameter String privateKey,
         @QueryParameter String secret, @QueryParameter String token) throws IOException {
@@ -364,7 +372,7 @@ public class Site extends AbstractDescribableImpl<Site> {
         return FormValidation.error("Read Timeout is not a number");
       }
 
-      Site site = new Site(name, mainURL, "BASIC", t);
+      Site site = new Site(name, mainURL, "BASIC", t, useV3Search);
 
       if (userName == null) {
         return FormValidation.error("UserName is empty or null.");
@@ -397,6 +405,7 @@ public class Site extends AbstractDescribableImpl<Site> {
     public FormValidation doValidateOAuth(@QueryParameter String name, @QueryParameter String url,
         @QueryParameter String loginType, @QueryParameter String timeout,
         @QueryParameter String readTimeout,
+        @QueryParameter Boolean useV3Search,
         @QueryParameter String userName, @QueryParameter String password,
         @QueryParameter String consumerKey, @QueryParameter String privateKey,
         @QueryParameter String secret, @QueryParameter String token) throws IOException {
@@ -445,7 +454,7 @@ public class Site extends AbstractDescribableImpl<Site> {
         return FormValidation.error("Read Timeout is not a number");
       }
 
-      Site site = new Site(name, mainURL, "OAUTH", t);
+      Site site = new Site(name, mainURL, "OAUTH", t, useV3Search);
 
       if (consumerKey == null) {
         return FormValidation.error("Consumer Key is empty or null.");

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraEndPoints.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraEndPoints.java
@@ -147,6 +147,10 @@ public interface JiraEndPoints {
   @POST("rest/api/2/search")
   Call<Object> searchIssues(@Body Object search);
 
+  // Search
+  @POST("rest/api/3/search/jql")
+  Call<Object> searchIssuesV3(@Body Object search);
+
   // Version
   @POST("rest/api/2/version")
   Call<Object> createVersion(@Body Object version);

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraService.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/service/JiraService.java
@@ -298,18 +298,32 @@ public class JiraService {
   }
 
   public ResponseData<Object> searchIssues(final String jql, final int startAt,
-      final int maxResults, final Object fields) {
+      final int maxResults, final Object fields, final String nextPageToken) {
     try {
       ImmutableMap.Builder<Object, Object> paramsMap = ImmutableMap.builder()
           .put("jql", jql)
-          .put("startAt", startAt)
           .put("maxResults", maxResults);
 
-      if (fields != null) {
-        paramsMap.put("fields", fields);
+      if (jiraSite.isUseV3Search()){
+        if (fields != null) {
+          if (fields instanceof String) {
+            paramsMap.put("fields", Arrays.asList(((String) fields).split(",")));
+          } else {
+            paramsMap.put("fields", fields);
+          }
+        }
+        if (nextPageToken != null) {
+          paramsMap.put("nextPageToken", nextPageToken);
+        }
+        return parseResponse(jiraEndPoints.searchIssuesV3(paramsMap.build()).execute());
       }
-
-      return parseResponse(jiraEndPoints.searchIssues(paramsMap.build()).execute());
+      else {
+        if (fields != null) {
+          paramsMap.put("fields", fields);
+        }
+        paramsMap.put("startAt", startAt);
+        return parseResponse(jiraEndPoints.searchIssues(paramsMap.build()).execute());
+      }
     } catch (Exception e) {
       return buildErrorResponse(e);
     }

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/JqlSearchStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/JqlSearchStep.java
@@ -38,6 +38,10 @@ public class JqlSearchStep extends BasicJiraStep {
   @DataBoundSetter
   private Object fields;
 
+  @Getter
+  @DataBoundSetter
+  private String nextPageToken;
+
   @DataBoundConstructor
   public JqlSearchStep(final String jql) {
     this.jql = jql;
@@ -83,7 +87,7 @@ public class JqlSearchStep extends BasicJiraStep {
         logger.println("JIRA: Site - " + siteName + " - Search JQL: " + step.getJql() + " startAt: "
             + step.getStartAt() + " maxResults: " + step.getMaxResults());
         response = jiraService
-            .searchIssues(step.getJql(), step.getStartAt(), step.getMaxResults(), step.getFields());
+            .searchIssues(step.getJql(), step.getStartAt(), step.getMaxResults(), step.getFields(), step.getNextPageToken());
       }
 
       return logResponse(response);

--- a/src/main/resources/org/thoughtslive/jenkins/plugins/jira/Site/config.jelly
+++ b/src/main/resources/org/thoughtslive/jenkins/plugins/jira/Site/config.jelly
@@ -18,6 +18,9 @@
   <f:entry field="readTimeout" title="Read Timeout(ms) ">
     <f:number default="10000"/>
   </f:entry>
+  <f:entry field="useV3Search" title="Use JIRA V3 Search API ">
+    <f:checkbox/>
+  </f:entry>
   <f:section title="Choose Login Type:">
     <f:radioBlock checked="${instance.isLoginType('BASIC')}" field="loginType" inline="true"
       name="loginType" title="Basic" value="BASIC">

--- a/src/main/resources/org/thoughtslive/jenkins/plugins/jira/Site/help-useV3Search.html
+++ b/src/main/resources/org/thoughtslive/jenkins/plugins/jira/Site/help-useV3Search.html
@@ -1,0 +1,2 @@
+Configure the Jira integration to use the V3 search API. This should be used with a Jira Cloud instance.<br />
+Leave this disabled for a Jira Data Center or Server instance as they only support V2.

--- a/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/JqlSearchStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/jira/steps/JqlSearchStepTest.java
@@ -30,7 +30,7 @@ public class JqlSearchStepTest extends BaseTest {
   public void setup() throws IOException, InterruptedException {
 
     final ResponseDataBuilder<Object> builder = ResponseData.builder();
-    when(jiraServiceMock.searchIssues(anyString(), anyInt(), anyInt(), any()))
+    when(jiraServiceMock.searchIssues(anyString(), anyInt(), anyInt(), any(), any()))
         .thenReturn(builder.successful(true).code(200).message("Success").build());
   }
 
@@ -55,7 +55,7 @@ public class JqlSearchStepTest extends BaseTest {
     stepExecution.run();
 
     // Assert Test
-    verify(jiraServiceMock, times(1)).searchIssues("TEST-1", 0, 1000, null);
+    verify(jiraServiceMock, times(1)).searchIssues("TEST-1", 0, 1000, null, null);
     assertThat(step.isFailOnError()).isEqualTo(true);
   }
 }


### PR DESCRIPTION
# Description

See [JENKINS-76037](https://issues.jenkins.io/browse/JENKINS-76037).

Atlassian is removing some v2 search API endpoints from Jira Cloud, including the JQL search endpoint that this plugin uses. We can't just outright update to use the v3 endpoint as Jira Data Center still uses a v2 endpoint. This PR adds a configuration option on a Site to specify whether or not to use the v3 search endpoint.

I have verified that installing this version in our instance has resolved our issues using the jiraJqlSearch step, though would note that as this is a new version of the search endpoint have found the response to be slightly different and have to modify some of our pipeline code accordingly.

I have adjusted existing unit tests to allow the build to succeed but have not yet had time to add a test specifically for this change, but figured that this is a breaking issue better to open the PR sooner than later to get a review of the implementation going.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description.
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests.
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description.
- [ ] Reviewed the code.
- [ ] Verified that the appropriate tests have been written or valid explanation given.
- [ ] If applicable, tested by installing this plugin on the Jenkins instance.
