### PR TITLE
Migrate from Commons Lang to native Java Platform functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <java.level>21</java.level>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     <jenkins.version>2.479.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <assertj-core.version>3.27.7</assertj-core.version>

--- a/src/main/java/org/thoughtslive/jenkins/plugins/jira/Site.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/jira/Site.java
@@ -36,7 +36,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.java.Log;
 import org.acegisecurity.Authentication;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.AncestorInPath;
@@ -179,14 +178,14 @@ public class Site extends AbstractDescribableImpl<Site> {
     }
 
     public FormValidation doCheckName(final @QueryParameter String name) {
-      if (StringUtils.isBlank(name)) {
+      if (Util.fixEmptyAndTrim(name) == null) {
         return FormValidation.error(Messages.required());
       }
       return FormValidation.ok();
     }
 
     public FormValidation doCheckUrl(final @QueryParameter String url) {
-      if (StringUtils.isBlank(url)) {
+      if (Util.fixEmptyAndTrim(url) == null) {
         return FormValidation.error(Messages.required());
       }
       try {
@@ -223,7 +222,7 @@ public class Site extends AbstractDescribableImpl<Site> {
           CredentialsProvider.USE_ITEM)) {
         return FormValidation.ok();
       }
-      if (StringUtils.isBlank(credentialsId)) {
+      if (Util.fixEmptyAndTrim(credentialsId) == null) {
         return FormValidation.warning(Messages.Site_emptyCredentialsId());
       }
 
@@ -242,7 +241,7 @@ public class Site extends AbstractDescribableImpl<Site> {
 
       StandardListBoxModel result = new StandardListBoxModel();
 
-      credentialsId = StringUtils.trimToEmpty(credentialsId);
+      credentialsId = Util.fixNull(credentialsId).trim();
       if (item == null) {
         if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
           return result.includeCurrentValue(credentialsId);


### PR DESCRIPTION
No need to use a third-party library when this functionality is available in the Java Platform.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

`StringUtils.isBlank(x)` → `Util.fixEmptyAndTrim(x) == null` and `StringUtils.trimToEmpty(x)` →
`Util.fixNull(x).trim()`, using the `hudson.Util` helpers. Also enables the `ban-commons-lang-2` enforcer
rule, which this plugin's parent POM already supports.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
