### PR TITLE
Align Jenkins platform with Jackson 2.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>plugin</artifactId>
     <groupId>org.jenkins-ci.plugins</groupId>
-    <version>6.2152.ve00a_731c3ce9</version>
+    <version>6.2211.v27f680c93c53</version>
   </parent>
   <artifactId>jira-steps</artifactId>
   <version>${revision}.${changelist}</version>
@@ -18,8 +18,8 @@
     <changelist>999999-SNAPSHOT</changelist>
     <java.level>21</java.level>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>2.479.3</jenkins.version>
+    <jenkins.baseline>2.528</jenkins.baseline>
+    <jenkins.version>2.528.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <assertj-core.version>3.27.7</assertj-core.version>
     <google.oauth.version>1.38.0</google.oauth.version>
@@ -77,7 +77,7 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <scope>import</scope>
         <type>pom</type>
-        <version>5054.v620b_5d2b_d5e6</version>
+        <version>6607.v3ed3d8ddfed8</version>
       </dependency>
       <dependency>
         <groupId>com.google.errorprone</groupId>
@@ -100,6 +100,7 @@
     <dependency>
       <artifactId>jackson2-api</artifactId>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <version>2.22.2-445.vdc613f1d8012</version>
     </dependency>
     <dependency>
       <artifactId>credentials</artifactId>
@@ -190,6 +191,9 @@
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
+        <configuration>
+          <targetBytecode>8</targetBytecode>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <artifactId>jackson-datatype-joda</artifactId>
       <groupId>com.fasterxml.jackson.datatype</groupId>
-      <version>2.13.3</version>
+      <version>2.22.2</version>
     </dependency>
     <dependency>
       <artifactId>adapter-rxjava</artifactId>


### PR DESCRIPTION
Companion fix for #280.

The Jackson datatype upgrade resolves the Jackson core family to 2.22.2, while the existing Jenkins Jackson API plugin exports 2.18.x. Maven Enforcer therefore rejects the mixed dependency graph before compilation.

This change:
- updates the Jenkins plugin parent, baseline, and BOM to a compatible supported platform;
- selects `jackson2-api` 2.22.2 explicitly because the current 2.528.x BOM still manages 2.21.2;
- keeps the two legacy Groovy 2.4 sources on Java 8 bytecode, avoiding the unsupported Java 17 target introduced by the newer parent while Java sources remain on the repository configured target.

Verification:
- `mvn -B --no-transfer-progress clean verify` on JDK 21: passed
- 147 tests passed, with zero failures, errors, or skips
- Maven Enforcer, SpotBugs, HPI packaging, and Spotless checks passed
- dependency tree resolves `jackson2-api`, `jackson-databind`, `jackson-core`, and `jackson-datatype-joda` at 2.22.2 (`jackson-annotations` uses its published 2.22 version)
- bytecode inspection: Java classes remain major version 61 and Groovy classes remain major version 52
- `git diff --check`: passed

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`